### PR TITLE
Summary (required)

### DIFF
--- a/cogs/base.py
+++ b/cogs/base.py
@@ -19,7 +19,7 @@ class Base(commands.Cog):
             await ctx.reply("That is not a valid extension.")
             return
 
-        await self.bot.reload_extension(extension)
+        await self.bot.reload_extension(f"cogs.{extension}")
         self.bot.std.info(f"Reloaded {extension} cog")
 
         await ctx.reply("Reloaded cog!")

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -43,7 +43,7 @@ class Recruit(commands.Cog):
 
         await ctx.reply("Registration complete!")
 
-    @commands.cooldown(1, 40, commands.BucketType.user)
+    # @commands.cooldown(1, 35, commands.BucketType.user)
     @commands.hybrid_command(name="recruit", with_app_command=True, description="Generate a list of nations to recruit")
     @app_commands.guilds(config.SERVER)
     async def recruit(self, ctx: commands.Context):
@@ -124,14 +124,7 @@ class Recruit(commands.Cog):
             self.bot.std.error(
                 "An unspecified error occured while trying to reach the NS API")
         else:
-            current_nations = [
-                nation.name for nation in self.bot.queue.nations]
-
-            # reverse the list because queue.add prepends to the queue
-            # (so we get most recent nations first)
-            for nation in reversed(new_nations):
-                if nation not in current_nations:
-                    self.bot.queue.add(nation)
+            self.bot.queue.update(new_nations)
 
     @tasks.loop(time=config.START_TIME)
     async def reporter(self):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -43,7 +43,7 @@ class Recruit(commands.Cog):
 
         await ctx.reply("Registration complete!")
 
-    # @commands.cooldown(1, 35, commands.BucketType.user)
+    @commands.cooldown(1, 35, commands.BucketType.user)
     @commands.hybrid_command(name="recruit", with_app_command=True, description="Generate a list of nations to recruit")
     @app_commands.guilds(config.SERVER)
     async def recruit(self, ctx: commands.Context):

--- a/components/rqueue.py
+++ b/components/rqueue.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import List
 
 # how long to keep nations in queue (in seconds)
 PRUNE_TIME: int = 3600
@@ -9,31 +10,40 @@ PRUNE_TIME: int = 3600
 class Nation:
     name: str
     time: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    recruited: bool = False
 
 
 @dataclass
 class Queue:
     nations: list[Nation] = field(default_factory=list)
 
-    def add(self, name: str):
-        nation = Nation(name)
+    def update(self, new_nations: List[str]):
+        for idx, nation in enumerate(self.nations):
+            if nation.recruited and nation.name in new_nations:
+                self.nations[idx] = Nation(name=nation.name, recruited=self.nations[idx].recruited)
+                new_nations.remove(nation.name)
 
-        self.nations.insert(0, nation)
+        for nation_name in reversed(new_nations):
+            nation = Nation(nation_name)
+
+            self.nations.insert(0, nation)
 
     def get_nations(self):
         self.prune()
 
-        resp = [nation.name for nation in self.nations[:8]]
+        resp = [nation.name for nation in self.nations if not nation.recruited][:8]
 
-        self.nations = [nation for nation in self.nations if nation.name not in resp]
+        for nation in self.nations:
+            if nation.name in resp:
+                nation.recruited = True
 
         return resp
 
     def prune(self):
         current_time = datetime.now(timezone.utc)
 
-        self.nations = [nation for nation in self.nations if (
-                current_time - nation.time).total_seconds() < PRUNE_TIME]
+        self.nations = [nation for nation in self.nations if (not nation.recruited and (
+            current_time - nation.time).total_seconds() < PRUNE_TIME) or (nation.recruited and (current_time - nation.time).total_seconds() < 30)]
 
     def purge(self):
         self.nations = []

--- a/components/views.py
+++ b/components/views.py
@@ -3,12 +3,11 @@ from discord.ui import View
 
 class RecruitView(View):
     def __init__(self):
-        super().__init__()
+        super().__init__(timeout=120)
 
     async def on_timeout(self):
-        self.value = None
         for child in self.children:
             child.disabled = True
 
-        await self.message.edit(view=self)
+        await self.message.edit(view=None)
         self.stop()

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ OPERATOR = "The United Peoples of Centrism"
 SERVER = discord.Object(id=1084622726800605184)
 # the role ID for the recruitment role
 RECRUIT_ROLE_ID = 1088807857442537654
+# the channel ID for the recruitment channel
+RECRUIT_CHANNEL_ID = 1088808524932452393
 # the channel ID for the reports channel
 REPORT_CHANNEL_ID = 1088812851738722334
 # the rate at which the bot will poll the NEWNATIONS API shard (in seconds)


### PR DESCRIPTION
- updated reload command to look for cogs in the cogs folder
- changed recruit command cooldown to 35
- extracted queue updating logic to a method on the queue
- added recruited flag on nation object
- nations are not immediately removed from queue when recruited, this flag is just set to true
- queue update method will refresh previously recruited nations if they are still returned from newnations (ie. in the 50 most recently founded nations), new nations will be added to the front of the queue as normal
- if a nation has been recruited and has a timestamp > 30s old (ie. two polling cycles), it will be purged from the queue. everything will be purged after an hour
- added my recruitment channel id back to config.py to make darc's life more difficult
- view (link button) will be removed on timeout (120 seconds after sending)