### PR TITLE
Updating Readme with better installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,21 @@
 - python 3.11
   - Ubuntu
     - sudo apt install python3.11 python3.11-dev
-    - sudo rm /usr/bin/python3
-    - sudo ln -s /usr/bin/python3.11 /usr/bin/python3
 - pip
   - Ubuntu
-    - sudo apt install python3-pip
+    - sudo apt install python3.11-pip
 - venv
   - Ubuntu
     - sudo apt install python3.11-venv
-    - python3 -m venv venv
+    - python3.11 -m venv venv
     - source venv/bin/activate
 
 # Installation
-- pip install -r requirements.txt
+- python3.11 -m pip install -r requirements.txt
 - mkdir logs
 - create a file called settings.json
   - Use settings.json.default as a starting point
   - Fill in correct values for settings.json
 
 # Execution
-- python3 main.py
+- python3.11 main.py


### PR DESCRIPTION
The old instructions tried to do an 'upgrade-in-place' to python3.11 which, as it turns out, is pretty damned destructive.

This is a different set of instructions, where 3.11 and whatever version of python3 remain side-by-side. (Ubuntu has a LOT of Python-based OS code, so moving your python3 install to 3.11 will send your OS into disarray. We don't want that.)