### PR TITLE
dynamic cooldowns & other neato stuff

### DIFF
--- a/cogs/error.py
+++ b/cogs/error.py
@@ -19,6 +19,10 @@ class Error(commands.Cog):
             await ctx.reply("The queue is empty!")
         elif isinstance(error, LastRecruitTooRecent):
             await ctx.reply(f"Last recruitment too recent! Please try again in {error.retry_in:.2f} seconds")
+        elif isinstance(error, SessionAlreadyStarted):
+            await ctx.reply("You are already in a recruitment session!")
+        elif isinstance(error, ActiveSession):
+            await ctx.reply("You cannot use /recruit while in a recruitment session!")
         elif isinstance(error, NotRecruitmentChannel):
             pass
         else:

--- a/cogs/error.py
+++ b/cogs/error.py
@@ -15,6 +15,10 @@ class Error(commands.Cog):
             await ctx.reply("You need the recruiter role to perform this command!")
         elif isinstance(error, NotRegistered):
             await ctx.reply("You need to register to perform this command! Use /register")
+        elif isinstance(error, EmptyQueue):
+            await ctx.reply("The queue is empty!")
+        elif isinstance(error, LastRecruitTooRecent):
+            await ctx.reply(f"Last recruitment too recent! Please try again in {error.retry_in:.2f} seconds")
         elif isinstance(error, NotRecruitmentChannel):
             pass
         else:

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -15,7 +15,7 @@ from components.bot import RecruitBot
 from components.config.config_manager import configInstance
 from components.users import User
 from components.checks import recruit_command_validated, register_command_validated
-from components.recruitment import get_recruit_embed
+from components.recruitment import RecruitType, get_recruit_embed
 
 
 # def guilds_wrapper(f):
@@ -88,7 +88,6 @@ class Recruit(commands.Cog):
 
         await ctx.reply("Registration complete!")
 
-    # @commands.cooldown(1, 35, commands.BucketType.user)
     @commands.hybrid_command(name="recruit", with_app_command=True, description="Generate a list of nations to recruit")
     @app_commands.guilds(configInstance.data.guild)
     async def recruit(self, ctx: commands.Context):
@@ -96,7 +95,7 @@ class Recruit(commands.Cog):
 
         recruit_command_validated(users=self.bot.rusers, ctx=ctx)
 
-        response_tuple = get_recruit_embed(user=ctx.author, bot=self.bot)
+        response_tuple = get_recruit_embed(user=ctx.author, bot=self.bot, rtype=RecruitType.COMMAND)
 
         if response_tuple:
             embed, view = response_tuple

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -48,7 +48,8 @@ class Recruit(commands.Cog):
             self.bot.std.info("Starting reporting")
             self.reporter.start()
 
-    @commands.hybrid_command(name="register", with_app_command=True, description="Register a nation and telegram template")
+    @commands.hybrid_command(name="register", with_app_command=True,
+                             description="Register a nation and telegram template")
     @app_commands.guilds(configInstance.data.guild)
     async def register(self, ctx: commands.Context, nation: str, template: str):
         await ctx.defer()
@@ -59,11 +60,12 @@ class Recruit(commands.Cog):
             ctx.author.id, nation.lower().replace(" ", "_"), template.replace("%", ""))
 
         self.bot.rusers.add(new_user)
-        self.bot.std.info(f"Registering user: {new_user.id} with nation: {new_user.nation} and template: {new_user.template}")
+        self.bot.std.info(
+            f"Registering user: {new_user.id} with nation: {new_user.nation} and template: {new_user.template}")
 
         await ctx.reply("Registration complete!")
 
-    @commands.cooldown(1, 35, commands.BucketType.user)
+    # @commands.cooldown(1, 35, commands.BucketType.user)
     @commands.hybrid_command(name="recruit", with_app_command=True, description="Generate a list of nations to recruit")
     @app_commands.guilds(configInstance.data.guild)
     async def recruit(self, ctx: commands.Context):
@@ -71,7 +73,7 @@ class Recruit(commands.Cog):
 
         recruit_command_validated(users=self.bot.rusers, ctx=ctx)
 
-        response_tuple = get_recruit_embed(user_id=ctx.author.id, bot=self.bot)
+        response_tuple = get_recruit_embed(user=ctx.author, bot=self.bot)
 
         if response_tuple:
             embed, view = response_tuple
@@ -139,7 +141,8 @@ class Recruit(commands.Cog):
             self.bot.std.info("Polling NEWNATIONS shard.")
 
             new_nations = bs(requests.get("https://www.nationstates.net/cgi-bin/api.cgi?q=newnations",
-                             headers=headers).text, "xml").NEWNATIONS.text.split(",")  # type: ignore -- BeautifulSoup returns a variant type.
+                                          headers=headers).text, "xml").NEWNATIONS.text.split(
+                ",")  # type: ignore -- BeautifulSoup returns a variant type.
         except:
             # certified error handling moment
             self.bot.std.error("An unspecified error occured while trying to reach the NS API")
@@ -179,7 +182,8 @@ class Recruit(commands.Cog):
         date = datetime.now().strftime("%Y-%m-%d")
 
         if reports_channel is not None:
-            await reports_channel.send(f"Daily Report: {date}\n```{summary}```")  # type: ignore -- Not sure why Pylance can't see this...
+            await reports_channel.send(
+                f"Daily Report: {date}\n```{summary}```")  # type: ignore -- Not sure why Pylance can't see this...
 
 
 async def setup(bot):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -163,8 +163,7 @@ class Recruit(commands.Cog):
         try:
             self.bot.std.info("Polling NEWNATIONS shard.")
 
-            new_nations = bs(requests.get("https://www.nationstates.net/cgi-bin/api.cgi?q=newnations",
-                                          headers=headers).text, "xml").NEWNATIONS.text.split(",")  # type: ignore
+            new_nations = bs(requests.get("https://www.nationstates.net/cgi-bin/api.cgi?q=newnations", headers=headers).text, "xml").NEWNATIONS.text.split(",")  ## type: ignore -- BeautifulSoup returns a variant type.
         except:
             # certified error handling moment
             self.bot.std.error("An unspecified error occurred while trying to reach the NS API")
@@ -205,8 +204,7 @@ class Recruit(commands.Cog):
         date = datetime.now().strftime("%Y-%m-%d")
 
         if reports_channel is not None:
-            await reports_channel.send(
-                f"Daily Report: {date}\n```{summary}```")  # type: ignore
+            await reports_channel.send(f"Daily Report: {date}\n```{summary}```")  # type: ignore
 
 
 async def setup(bot):

--- a/cogs/sessions.py
+++ b/cogs/sessions.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timezone
+from discord import app_commands
+from discord.ext import commands
+from typing import Dict, Optional
+
+from components.bot import RecruitBot
+from components.config.config_manager import configInstance
+from components.errors import SessionAlreadyStarted
+from components.session import Session
+
+
+class Sessions(commands.Cog):
+    bot: RecruitBot
+    sessions: Dict[int, Session] = {}
+
+    def __init__(self, bot: RecruitBot):
+        self.bot = bot
+
+    def cog_unload(self):
+        for session in self.sessions.values():
+            session.test.cancel()
+
+        for user in self.bot.rusers.users:
+            user.active_session = False
+
+    @commands.hybrid_command(name="session", with_app_command=True, description="Start a session")
+    @app_commands.guilds(configInstance.data.guild)
+    async def session(self, ctx: commands.Context, interval: int = 45):
+        if self.sessions.get(ctx.author.id):
+            raise SessionAlreadyStarted(ctx.author)
+
+        self.bot.rusers.get(ctx.author).active_session = True
+
+        if interval < 45:
+            interval = 45
+
+        session = Session(self.bot, ctx.author, ctx.channel.id, interval)
+        self.sessions[ctx.author.id] = session
+
+        await ctx.reply(
+            f"{datetime.now(timezone.utc).strftime('%H:%M:%S')} - Session started for user {ctx.author}! Interval: {interval} seconds")
+
+
+async def setup(bot):
+    await bot.add_cog(Sessions(bot))

--- a/cogs/sessions.py
+++ b/cogs/sessions.py
@@ -34,8 +34,7 @@ class Sessions(commands.Cog):
         if interval < 45:
             interval = 45
 
-        session = Session(self.bot, ctx.author, ctx.channel.id, interval)
-        self.sessions[ctx.author.id] = session
+        self.sessions[ctx.author.id] = Session(self.bot, ctx.author, ctx.channel.id, interval)
 
         await ctx.reply(
             f"{datetime.now(timezone.utc).strftime('%H:%M:%S')} - Session started for user {ctx.author}! Interval: {interval} seconds")

--- a/cogs/sessions.py
+++ b/cogs/sessions.py
@@ -25,14 +25,14 @@ class Sessions(commands.Cog):
 
     @commands.hybrid_command(name="session", with_app_command=True, description="Start a session")
     @app_commands.guilds(configInstance.data.guild)
-    async def session(self, ctx: commands.Context, interval: int = 45):
+    async def session(self, ctx: commands.Context, interval: int = 35):
         if self.sessions.get(ctx.author.id):
             raise SessionAlreadyStarted(ctx.author)
 
         self.bot.rusers.get(ctx.author).active_session = True
 
-        if interval < 45:
-            interval = 45
+        if interval < 35:
+            interval = 35
 
         self.sessions[ctx.author.id] = Session(self.bot, ctx.author, ctx.channel.id, interval)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -15,7 +15,7 @@ class RecruitBot(commands.Bot):
     queue: Queue
     daily: logging.Logger
     std: logging.Logger
-    
+
     def __init__(self):
         intents = discord.Intents.default()
         intents.message_content = True
@@ -28,7 +28,7 @@ class RecruitBot(commands.Bot):
         self.daily, self.std = create_loggers()
         configInstance.set_logger(self.std)
 
-        self.default_cogs = ["base", "error", "recruit"]
+        self.default_cogs = ["base", "error", "recruit", "sessions"]
 
     async def setup_hook(self):
         # await self.load_extension("recruit")

--- a/components/checks.py
+++ b/components/checks.py
@@ -2,7 +2,7 @@ from discord.ext import commands
 
 from components.config.config_manager import configInstance
 from components.users import Users
-from components.errors import NotRegistered, NotRecruiter, NotRecruitmentChannel
+from components.errors import NotRegistered, NotRecruiter, NotRecruitmentChannel, ActiveSession
 
 
 def register_command_validated(ctx: commands.Context) -> bool:
@@ -10,7 +10,7 @@ def register_command_validated(ctx: commands.Context) -> bool:
 
 
 def recruit_command_validated(users: Users, ctx: commands.Context) -> bool:
-    return in_recruit_channel(ctx) and is_registered(users, ctx) and is_recruiter(ctx)
+    return in_recruit_channel(ctx) and is_registered(users, ctx) and is_recruiter(ctx) and not in_active_session(users, ctx)
 
 
 def in_recruit_channel(ctx: commands.Context) -> bool:
@@ -30,5 +30,12 @@ def is_registered(users: Users, ctx: commands.Context) -> bool:
 def is_recruiter(ctx: commands.Context) -> bool:
     if ctx.guild.get_role(configInstance.data.recruit_role_id) not in ctx.author.roles:  # type: ignore
         raise NotRecruiter(ctx.author)  # type: ignore
+    else:
+        return True
+
+
+def in_active_session(users: Users, ctx: commands.Context) -> bool:
+    if users.get(ctx.author).active_session:
+        raise ActiveSession(ctx.author)
     else:
         return True

--- a/components/checks.py
+++ b/components/checks.py
@@ -15,20 +15,20 @@ def recruit_command_validated(users: Users, ctx: commands.Context) -> bool:
 
 def in_recruit_channel(ctx: commands.Context) -> bool:
     if ctx.channel.id != configInstance.data.recruit_channel_id:
-        raise NotRecruitmentChannel(ctx.author) # type: ignore
+        raise NotRecruitmentChannel(ctx.author)  # type: ignore
     else:
         return True
 
 
 def is_registered(users: Users, ctx: commands.Context) -> bool:
-    if not users.get(ctx.author.id):
-        raise NotRegistered(ctx.author) # type: ignore
+    if not users.get(ctx.author):
+        raise NotRegistered(ctx.author)  # type: ignore
     else:
         return True
 
 
 def is_recruiter(ctx: commands.Context) -> bool:
-    if ctx.guild.get_role(configInstance.data.recruit_role_id) not in ctx.author.roles: # type: ignore
-        raise NotRecruiter(ctx.author) # type: ignore
+    if ctx.guild.get_role(configInstance.data.recruit_role_id) not in ctx.author.roles:  # type: ignore
+        raise NotRecruiter(ctx.author)  # type: ignore
     else:
         return True

--- a/components/config/config_model.py
+++ b/components/config/config_model.py
@@ -28,6 +28,10 @@ class ConfigData:
         return self._report_channel_id
 
     @property
+    def status_message_id(self) -> int:
+        return self._status_message_id
+
+    @property
     def polling_rate(self) -> int:
         return self._polling_rate
 
@@ -51,6 +55,7 @@ class ConfigData:
             recruitChannelId=dict['recruitChannelId'],
             recruitRoleId=dict['recruitRoleId'],
             reportChannelId=dict['reportChannelId'],
+            statusMessageId=dict['statusMessageId'],
             pollingRate=dict['pollingRate'],
             period=dict['period'],
             periodMax=dict['periodMax'],
@@ -58,12 +63,14 @@ class ConfigData:
         )
         return
 
-    def __init__(self, operator="", guildId=0, recruitChannelId=0, recruitRoleId=0, reportChannelId=0,  pollingRate=0, period=0, periodMax=0, botToken="") -> None:
+    def __init__(self, operator="", guildId=0, recruitChannelId=0, recruitRoleId=0, reportChannelId=0,
+                 statusMessageId=0, pollingRate=0, period=0, periodMax=0, botToken="") -> None:
         self._operator = operator
         self._guild = discord.Object(id=guildId)
         self._recruit_channel_id = recruitChannelId
-        self._recruit_role_id=recruitRoleId
+        self._recruit_role_id = recruitRoleId
         self._report_channel_id = reportChannelId
+        self._status_message_id = statusMessageId
         self._polling_rate = pollingRate
         self._period = period
         self._period_max = periodMax

--- a/components/errors.py
+++ b/components/errors.py
@@ -4,18 +4,42 @@ from discord.ext import commands
 
 
 class NotRegistered(commands.CommandError):
+    user: discord.User
+
     def __init__(self, user: discord.User):
         self.user = user
         super().__init__(message="Not Registered!")
 
 
 class NotRecruiter(commands.CommandError):
+    user: discord.User
+
     def __init__(self, user: discord.User):
         self.user = user
         super().__init__(message="You don't have the 'Recruiter' role!")
 
 
 class NotRecruitmentChannel(commands.CommandError):
+    user: discord.User
+
     def __init__(self, user: discord.User):
         self.user = user
         super().__init__(message="Wrong channel!")
+
+
+class EmptyQueue(commands.CommandError):
+    user: discord.User
+
+    def __init__(self, user: discord.User):
+        self.user = user
+        super().__init__(message="The queue is empty!")
+
+
+class LastRecruitTooRecent(commands.CommandError):
+    user: discord.User
+    retry_in: float
+
+    def __init__(self, user: discord.User, retry_in: float):
+        self.user = user
+        self.retry_in = retry_in
+        super().__init__(message="You have already recruited someone recently!")

--- a/components/errors.py
+++ b/components/errors.py
@@ -43,3 +43,19 @@ class LastRecruitTooRecent(commands.CommandError):
         self.user = user
         self.retry_in = retry_in
         super().__init__(message="You have already recruited someone recently!")
+
+
+class SessionAlreadyStarted(commands.CommandError):
+    user: discord.User
+
+    def __init__(self, user: discord.User):
+        self.user = user
+        super().__init__(message="You already have a session started!")
+
+
+class ActiveSession(commands.CommandError):
+    user: discord.User
+
+    def __init__(self, user: discord.User):
+        self.user = user
+        super().__init__(message="You cannot use /recruit while in a session!")

--- a/components/recruitment.py
+++ b/components/recruitment.py
@@ -1,6 +1,7 @@
 import discord
 
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Optional, Tuple
 
 from components.bot import RecruitBot
@@ -8,7 +9,12 @@ from components.views import RecruitView
 from components.errors import EmptyQueue, LastRecruitTooRecent, NotRegistered
 
 
-def get_recruit_embed(user: discord.User, bot: RecruitBot) -> Tuple[discord.Embed, RecruitView]:
+class RecruitType(Enum):
+    COMMAND = 1,
+    SESSION = 2
+
+
+def get_recruit_embed(user: discord.User, bot: RecruitBot, rtype: RecruitType) -> Tuple[discord.Embed, RecruitView | discord.ui.Button]:
     recruiter = bot.rusers.get(user)
 
     if recruiter.allow_recruitment_at > datetime.now(timezone.utc):
@@ -28,11 +34,18 @@ def get_recruit_embed(user: discord.User, bot: RecruitBot) -> Tuple[discord.Embe
     embed.set_footer(
         text=f"Initiated by {recruiter.nation} at {datetime.now(timezone.utc).strftime('%H:%M:%S')}")
 
-    # link buttons can't be created in a subclassed view, so this is basically
-    # an empty view with nothing but an on_timeout method
-    view = RecruitView()
-    view.add_item(discord.ui.Button(label="Open Telegram", style=discord.ButtonStyle.link,
-                                    url=f"https://www.nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{recruiter.template}%25"))
+    match rtype:
+        case RecruitType.COMMAND:
+
+            # link buttons can't be created in a subclassed view, so this is basically
+            # an empty view with nothing but an on_timeout method
+            view = RecruitView()
+            view.add_item(discord.ui.Button(label="Open Telegram", style=discord.ButtonStyle.link,
+                                            url=f"https://www.nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{recruiter.template}%25"))
+
+        case RecruitType.SESSION:
+            view = discord.ui.Button(label="Open Telegram", style=discord.ButtonStyle.link,
+                                     url=f"https://www.nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{recruiter.template}%25")
 
     recruiter.set_next_recruitment(len(nations))
     bot.daily.info(f"{recruiter.nation} {len(nations)}")

--- a/components/recruitment.py
+++ b/components/recruitment.py
@@ -5,36 +5,36 @@ from typing import Optional, Tuple
 
 from components.bot import RecruitBot
 from components.views import RecruitView
+from components.errors import EmptyQueue, LastRecruitTooRecent, NotRegistered
 
 
-def get_recruit_embed(user_id: int, bot: RecruitBot) -> Optional[Tuple[discord.Embed, RecruitView]]:
-    user = bot.rusers.get(user_id)
+def get_recruit_embed(user: discord.User, bot: RecruitBot) -> Tuple[discord.Embed, RecruitView]:
+    recruiter = bot.rusers.get(user)
 
-    # this will never happen because we validate that the user exists in the command,
-    # but my IDE is complaining without it
-    if not user:
-        return None
+    if recruiter.allow_recruitment_at > datetime.now(timezone.utc):
+        raise LastRecruitTooRecent(user, (recruiter.allow_recruitment_at - datetime.now(timezone.utc)).total_seconds())
 
     nations = bot.queue.get_nations()
 
     if not nations:
-        return None
+        raise EmptyQueue(user)
 
     color = int("2d0001", 16)
     embed = discord.Embed(title=f"Recruit", color=color)
     embed.add_field(name="Nations", value="\n".join(
         [f"https://www.nationstates.net/nation={nation}" for nation in nations]))
     embed.add_field(name="Template",
-                    value=f"```{user.template}```", inline=False)
+                    value=f"```{recruiter.template}```", inline=False)
     embed.set_footer(
-        text=f"Initiated by {user.nation} at {datetime.now(timezone.utc).strftime('%H:%M:%S')}")
+        text=f"Initiated by {recruiter.nation} at {datetime.now(timezone.utc).strftime('%H:%M:%S')}")
 
     # link buttons can't be created in a subclassed view, so this is basically
     # an empty view with nothing but an on_timeout method
     view = RecruitView()
     view.add_item(discord.ui.Button(label="Open Telegram", style=discord.ButtonStyle.link,
-                                    url=f"https://www.nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{user.template}%25"))
+                                    url=f"https://www.nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{recruiter.template}%25"))
 
-    bot.daily.info(f"{user.nation} {len(nations)}")
+    recruiter.set_next_recruitment(len(nations))
+    bot.daily.info(f"{recruiter.nation} {len(nations)}")
 
     return embed, view

--- a/components/rqueue.py
+++ b/components/rqueue.py
@@ -17,6 +17,7 @@ class Nation:
 
 @dataclass
 class Queue:
+    last_update: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     nations: list[Nation] = field(default_factory=list)
 
     def update(self, new_nations: List[str]):
@@ -31,6 +32,11 @@ class Queue:
             nation = Nation(nation_name)
 
             self.nations.insert(0, nation)
+
+        self.last_update = datetime.now(timezone.utc)
+
+    def get_nation_count(self) -> int:
+        return len([nation for nation in self.nations if not nation.recruited])
 
     def get_nations(self) -> List[str]:
         self.prune()

--- a/components/session.py
+++ b/components/session.py
@@ -1,0 +1,36 @@
+import discord
+
+from datetime import datetime, timezone
+from discord.ext import tasks
+from typing import Optional
+
+from components.bot import RecruitBot
+from components.views import SessionView
+
+
+class Session:
+    bot: RecruitBot
+    user: discord.User
+    interval: int = 45
+    strikes: int = 0
+    channel: Optional[discord.TextChannel] = None
+
+    def __init__(self, bot: RecruitBot, user: discord.User, channel_id: int, interval):
+        self.bot = bot
+        self.user = user
+        self.channel = self.bot.get_channel(channel_id)
+
+        self.interval = interval
+        self.test.change_interval(seconds=self.interval)
+
+        self.test.start()
+
+    @tasks.loop(seconds=interval)
+    async def test(self):
+        if self.strikes >= 2:
+            self.test.cancel()
+            self.bot.rusers.get(self.user).active_session = False
+            await self.channel.send(f"Ending <@!{self.user.id}>'s recruitment session due to inactivity.")
+        else:
+            view = SessionView(self)
+            view.message = await self.channel.send(f"<@!{self.user.id}>", view=view)

--- a/components/users.py
+++ b/components/users.py
@@ -1,8 +1,12 @@
+import discord
 import json
 
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
+from datetime import datetime, timedelta, timezone
 from typing import Self, List
+
+from components.errors import NotRegistered
 
 
 @dataclass
@@ -10,6 +14,10 @@ class User:
     id: int
     nation: str
     template: str
+    allow_recruitment_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def set_next_recruitment(self, num_nations: int):
+        self.allow_recruitment_at = datetime.now(timezone.utc) + timedelta(seconds=num_nations * 5)
 
 
 @dataclass_json
@@ -37,11 +45,11 @@ class Users:
 
         self.save()
 
-    def get(self, id: int):
-        for user in self.users:
-            if user.id == id:
-                return user
-        return None
+    def get(self, user: discord.User) -> User:
+        for recruiter in self.users:
+            if recruiter.id == user.id:
+                return recruiter
+        raise NotRegistered(user)
 
     def ids(self) -> List[int]:
         return [user.id for user in self.users]

--- a/components/users.py
+++ b/components/users.py
@@ -14,6 +14,7 @@ class User:
     id: int
     nation: str
     template: str
+    active_session: bool = False
     allow_recruitment_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     def set_next_recruitment(self, num_nations: int):

--- a/components/views.py
+++ b/components/views.py
@@ -1,3 +1,5 @@
+import discord
+
 from discord import Message
 from discord.ui import View
 
@@ -13,4 +15,57 @@ class RecruitView(View):
         #    child.disabled = True
 
         await self.message.edit(view=None)
+        self.stop()
+
+
+class SessionView(View):
+    message: Message
+    # session: Session
+
+    def __init__(self, session):
+        from components.session import Session
+        super().__init__(timeout=session.interval)
+        self.session: Session = session
+
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+
+        self.session.strikes += 1
+        await self.message.edit(view=self)
+        self.stop()
+
+    @discord.ui.button(label="✓", style=discord.ButtonStyle.green)
+    async def ack_callback(self, interaction: discord.Interaction, button):
+        from components.recruitment import RecruitType, get_recruit_embed
+
+        if interaction.user.id != self.session.user.id:
+            await interaction.response.send_message("You canot interact with another user's session.")
+            return
+
+        self.session.strikes = 0
+
+        for child in self.children:
+            child.disabled = True
+
+        embed, link_button = get_recruit_embed(self.session.user, self.session.bot, RecruitType.SESSION)
+
+        self.add_item(link_button)
+
+        await interaction.response.edit_message(embed=embed, view=self)
+        self.stop()
+
+    @discord.ui.button(label="❌", style=discord.ButtonStyle.red)
+    async def cancel_callback(self, interaction: discord.Interaction, button):
+        if interaction.user.id != self.session.user.id:
+            await interaction.response.send_message("You canot interact with another user's session.")
+            return
+
+        self.session.test.cancel()
+        self.session.bot.rusers.get(self.session.user).active_session = False
+
+        for child in self.children:
+            child.disabled = True
+
+        await interaction.response.edit_message(content="Session ended", view=self)
         self.stop()

--- a/settings.json.default
+++ b/settings.json.default
@@ -4,6 +4,7 @@
   "reportChannelId": 0,
   "recruitChannelId": 0,
   "recruitRoleId": 0,
+  "statusMessageId": 0,
   "pollingRate": 15,
   "period": 30,
   "periodMax": 5,


### PR DESCRIPTION
- users.get now returns a user or raises an error; no need to handle in commands
- queue.get_nations does the same
- checks/errors now take discord.User instead of an id or a users.User
- added custom errors for empty queue and recent recruitment (which includes a retry after value)
- the time that the next recruitment is allowed is now dynamic based on the number of nations recruited last