### PR TITLE
queue debug (print :trollface:) command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ ENV/
 logs/*
 settings.json
 config.json
+queue.txt

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -72,6 +72,22 @@ class Recruit(commands.Cog):
 
         await ctx.send(embed=embed)
 
+    @commands.hybrid_command(name="pq", with_app_command=True, description="Print the queue")
+    @app_commands.guilds(configInstance.data.guild)
+    async def pq(self, ctx: commands.Context):
+        await ctx.defer()
+
+        if ctx.author.id not in [110600636319440896, 230778695713947648, 134499733849899008]:
+            await ctx.reply("You do not have permission to use this command.")
+            return
+
+        nations = self.bot.queue.get_full_queue()
+
+        with open("queue.txt", "w") as out_file:
+            out_file.write("\n".join([f"{nation.name} {nation.recruited} {nation.time}" for nation in nations]))
+
+        await ctx.reply(file=discord.File("queue.txt"))
+
     @commands.hybrid_command(name="register", with_app_command=True,
                              description="Register a nation and telegram template")
     @app_commands.guilds(configInstance.data.guild)

--- a/components/rqueue.py
+++ b/components/rqueue.py
@@ -37,6 +37,9 @@ class Queue:
 
         self.last_update = datetime.now(timezone.utc)
 
+    def get_full_queue(self) -> List[Nation]:
+        return self.nations
+
     def get_nation_count(self) -> int:
         return len([nation for nation in self.nations if not nation.recruited])
 
@@ -58,8 +61,8 @@ class Queue:
         current_time = datetime.now(timezone.utc)
 
         self.nations = [nation for nation in self.nations if (not nation.recruited and (
-                current_time - nation.time).total_seconds() < PRUNE_TIME) or (
-                                nation.recruited and (current_time - nation.time).total_seconds() < 30)]
+            current_time - nation.time).total_seconds() < PRUNE_TIME) or (
+            nation.recruited and (current_time - nation.time).total_seconds() < 30)]
 
     def purge(self):
         self.nations = []


### PR DESCRIPTION
- added get_full_queue method to queue
- added pq command to recruit cog, it will just upload a text file with the entire queue to the recruitment channel
   - it can only be run by the three of us
   - i basically want to see if we're getting duplicate nations or if nations that have been recruited are somehow not being marked as such