### PR TITLE
resolving expected issues with sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ ENV/
 logs/*
 settings.json
 config.json
+queue.txt

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -166,7 +166,7 @@ class Recruit(commands.Cog):
 
             new_nations = bs(
                 requests.get("https://www.nationstates.net/cgi-bin/api.cgi?q=newnations", headers=headers).text,
-                "xml").NEWNATIONS.text.split(",")  ## type: ignore -- BeautifulSoup returns a variant type.
+                "xml").NEWNATIONS.text.split(",")  # type: ignore -- BeautifulSoup returns a variant type.
         except:
             # certified error handling moment
             self.bot.std.error("An unspecified error occurred while trying to reach the NS API")

--- a/cogs/sessions.py
+++ b/cogs/sessions.py
@@ -11,14 +11,13 @@ from components.session import Session
 
 class Sessions(commands.Cog):
     bot: RecruitBot
-    sessions: Dict[int, Session] = {}
 
     def __init__(self, bot: RecruitBot):
         self.bot = bot
 
     def cog_unload(self):
-        for session in self.sessions.values():
-            session.test.cancel()
+        for session in self.bot.sessions.values():
+            session.recruit_loop.cancel()
 
         for user in self.bot.rusers.users:
             user.active_session = False
@@ -26,7 +25,7 @@ class Sessions(commands.Cog):
     @commands.hybrid_command(name="session", with_app_command=True, description="Start a session")
     @app_commands.guilds(configInstance.data.guild)
     async def session(self, ctx: commands.Context, interval: int = 35):
-        if self.sessions.get(ctx.author.id):
+        if self.bot.sessions.get(ctx.author.id):
             raise SessionAlreadyStarted(ctx.author)
 
         self.bot.rusers.get(ctx.author).active_session = True
@@ -34,7 +33,7 @@ class Sessions(commands.Cog):
         if interval < 35:
             interval = 35
 
-        self.sessions[ctx.author.id] = Session(self.bot, ctx.author, ctx.channel.id, interval)
+        self.bot.sessions[ctx.author.id] = Session(self.bot, ctx.author, ctx.channel.id, interval)
 
         await ctx.reply(
             f"{datetime.now(timezone.utc).strftime('%H:%M:%S')} - Session started for user {ctx.author}! Interval: {interval} seconds")

--- a/cogs/sessions.py
+++ b/cogs/sessions.py
@@ -22,6 +22,8 @@ class Sessions(commands.Cog):
         for user in self.bot.rusers.users:
             user.active_session = False
 
+        self.bot.sessions = {}
+
     @commands.hybrid_command(name="session", with_app_command=True, description="Start a session")
     @app_commands.guilds(configInstance.data.guild)
     async def session(self, ctx: commands.Context, interval: int = 35):

--- a/components/bot.py
+++ b/components/bot.py
@@ -1,13 +1,14 @@
+import discord
 import logging
 
-import discord
-
 from discord.ext import commands
+from typing import Dict
 
 from components.config.config_manager import configInstance
 from components.loggers import create_loggers
 from components.users import Users
 from components.rqueue import Queue
+from components.session import Session
 
 
 class RecruitBot(commands.Bot):
@@ -15,6 +16,7 @@ class RecruitBot(commands.Bot):
     queue: Queue
     daily: logging.Logger
     std: logging.Logger
+    sessions: Dict[int, Session] = {}
 
     def __init__(self):
         intents = discord.Intents.default()

--- a/components/session.py
+++ b/components/session.py
@@ -4,19 +4,20 @@ from datetime import datetime, timezone
 from discord.ext import tasks
 from typing import Optional
 
-from components.bot import RecruitBot
 from components.views import SessionView
 
 
 class Session:
-    bot: RecruitBot
+    # bot: RecruitBot
     user: discord.User
     interval: int = 45
     strikes: int = 0
     channel: Optional[discord.TextChannel] = None
 
-    def __init__(self, bot: RecruitBot, user: discord.User, channel_id: int, interval):
-        self.bot = bot
+    def __init__(self, bot, user: discord.User, channel_id: int, interval):
+        from components.bot import RecruitBot
+
+        self.bot: RecruitBot = bot
         self.user = user
         self.channel = self.bot.get_channel(channel_id)
 
@@ -30,8 +31,9 @@ class Session:
         self.bot.std.info(f"Session looping for user {self.user.name}")
         if self.strikes >= 2:
             self.recruit_loop.cancel()
+            self.bot.sessions.pop(self.user.id)
             self.bot.rusers.get(self.user).active_session = False
             await self.channel.send(f"Ending <@!{self.user.id}>'s recruitment session due to inactivity.")
         else:
-            view = SessionView(self)
+            view = SessionView(self, bot=self.bot)
             view.message = await self.channel.send(f"<@!{self.user.id}>", view=view)


### PR DESCRIPTION
- moved sessions dict to bot from sessions cog
- pop sessions from dict when a session ends instead of just ending the associated task
- handled error when user acknowledges a session while the queue is empty
- corrected my spelling of 'cannot'

I did not add the pq/print queue command into this version, I do not think we need it 