### PR TITLE
Improved cooldowns & other improvements

### DIFF
--- a/components/errors.py
+++ b/components/errors.py
@@ -31,7 +31,7 @@ class NotRecruitManager(commands.CommandError):
 
         super().__init__(message=f"{self.user.name} is not a recruit manager")
 
-        
+
 class NotRegistered(commands.CommandError):
     def __init__(self, user: discord.User):
         self.user = user
@@ -44,3 +44,11 @@ class TooManyRequests(commands.CommandError):
         self.reset_in = reset_in
 
         super().__init__(message=f"too many requests made in the current bucket, reset in {reset_in:.2f} seconds.")
+
+
+class NationNotFound(commands.CommandError):
+    def __init__(self, user: discord.User, nation: str):
+        self.user = user
+        self.nation = nation
+
+        super().__init__(message=f"{self.nation} does not exist")

--- a/components/recruiter.py
+++ b/components/recruiter.py
@@ -8,3 +8,16 @@ class Recruiter:
     template: str
     discord_id: int
     next_recruitment_at: datetime
+    founded_time: datetime
+
+    def get_cooldown(self, nation_count: int = 8):
+        # cooldown per nation starts at approximately 14 seconds and decreases linearly until it is 5 seconds
+        # when the nation is 18 months old
+        seconds = (datetime.now(timezone.utc) - self.founded_time).days / 60
+
+        if seconds > 9:
+            return 5 * nation_count
+        elif seconds < 0:
+            return 14 * nation_count
+        else:
+            return 5 + (9 - seconds) * nation_count


### PR DESCRIPTION
- recruitment cooldowns are based on nation age (users will need to reregister in order to take advantage of this)
- the recruitment message now disappears when a user's recruitment cooldown is ending. this can be used as a basic timer
- added NationNotFound error
- users no longer need the 'Recruit Manager' role to generate reports

This PR requires an additional field in the users table:
ALTER TABLE users ADD foundedTime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;