### PR TITLE
Filters

### DIFF
--- a/cogs/base.py
+++ b/cogs/base.py
@@ -1,18 +1,7 @@
-import discord
-
 from discord.ext import commands
 
 from components.bot import Bot
-
-
-def is_authorized():
-    def predicate(ctx: commands.Context):
-        if ctx.author.id not in [230778695713947648, 110600636319440896]:
-            raise commands.MissingPermissions(["Bot Administrator"])
-
-        return True
-
-    return commands.check(predicate)
+from components.checks import is_global_admin
 
 
 class Base(commands.Cog):
@@ -20,7 +9,7 @@ class Base(commands.Cog):
         self.bot = bot
 
     @commands.command(name="sync", description="Sync slash commands")
-    @is_authorized()
+    @is_global_admin()
     async def sync(self, ctx: commands.Context):
         await ctx.defer()
 
@@ -29,13 +18,13 @@ class Base(commands.Cog):
         await ctx.reply("Done!")
 
     @commands.command(name="reload", description="Reload a cog")
-    @is_authorized()
+    @is_global_admin()
     async def reload(self, ctx: commands.Context, cog: str):
         await self.bot.reload_extension(f"cogs.{cog}")
         await ctx.reply(f"Reloaded cog: {cog}")
 
     @commands.command(name="kill", description="Put the bot to sleep")
-    @is_authorized()
+    @is_global_admin()
     async def kill(self, ctx: commands.Context):
         await ctx.reply("Goodbye!")
         await self.bot.close()

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
 
 from components.bot import Bot
-from components.checks import is_global_admin
+from components.checks import is_global_admin_text
 
 
 class Base(commands.Cog):
@@ -9,22 +9,21 @@ class Base(commands.Cog):
         self.bot = bot
 
     @commands.command(name="sync", description="Sync slash commands")
-    @is_global_admin()
+    @commands.check(is_global_admin_text)
     async def sync(self, ctx: commands.Context):
         await ctx.defer()
 
-        synced = await self.bot.tree.sync()
-        print(synced)
+        await self.bot.tree.sync()
         await ctx.reply("Done!")
 
     @commands.command(name="reload", description="Reload a cog")
-    @is_global_admin()
+    @commands.check(is_global_admin_text)
     async def reload(self, ctx: commands.Context, cog: str):
         await self.bot.reload_extension(f"cogs.{cog}")
         await ctx.reply(f"Reloaded cog: {cog}")
 
     @commands.command(name="kill", description="Put the bot to sleep")
-    @is_global_admin()
+    @commands.check(is_global_admin_text)
     async def kill(self, ctx: commands.Context):
         await ctx.reply("Goodbye!")
         await self.bot.close()

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -206,7 +206,10 @@ class RecruitmentCog(commands.Cog):
 
     @tasks.loop(seconds=15)
     async def refresh_embeds(self):
-        await self.bot.update_status_embeds()
+        try:
+            await self.bot.update_status_embeds()
+        except Exception:
+            logger.exception("error in embed refresh task")
 
     @app_commands.command(name="register", description="Register a channel for recruitment")
     @app_commands.guild_only()

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -18,18 +18,27 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
         super().__init__(timeout=None)
         self.bot = bot
 
-    region = discord.ui.TextInput(label="Region", min_length=1, max_length=40)
+    region = discord.ui.Label(
+        text="Region",
+        component=discord.ui.TextInput(
+            placeholder="Enter your region name",
+            min_length=1,
+            max_length=40,
+        )
+    )
 
     async def on_submit(self, interaction: discord.Interaction):
         if self.is_finished() and self.region.value != "":
             raise ValueError("Region cannot be empty")
 
+        assert isinstance(self.region.component, discord.ui.TextInput)
+
+        region = self.region.component.value.strip().lower().replace(" ", "_")
+
+        message = await interaction.channel.send(view=RecruitView(self.bot))
+
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:
-                region = self.region.value.strip().lower().replace(" ", "_")
-
-                message = await interaction.channel.send(view=RecruitView(self.bot))
-
                 try:
                     await cur.execute(
                         "INSERT INTO recruitment_channels (serverId, channelId, messageId) VALUES (%s, %s, %s);",
@@ -60,43 +69,66 @@ class RegisterRecruiterModal(Modal, title="Registration"):
         super().__init__(timeout=None)
         self.bot = bot
 
-    nation = discord.ui.TextInput(label="Nation", placeholder="Enter your nation name", min_length=3, max_length=40)
-
-    recruitment_template = discord.ui.TextInput(
-        label="Recruitment Template", placeholder="Enter your recruitment template", min_length=10, max_length=20
+    nation = discord.ui.Label(
+        text="Nation",
+        component=discord.ui.TextInput(
+            placeholder="Enter your nation name",
+            min_length=3,
+            max_length=40,
+        )
     )
 
-    session_length = discord.ui.TextInput(
-        label="Session Length (in seconds)", placeholder="Session length (45 - 600 seconds)", default="60", min_length=1, max_length=3
+    recruitment_template = discord.ui.Label(
+        text="Recruitment Template",
+        component=discord.ui.TextInput(
+            placeholder="Enter your recruitment template",
+            min_length=10,
+            max_length=20,
+        )
+    )
+
+    session_length = discord.ui.Label(
+        text="Session Length (in seconds)",
+        component=discord.ui.TextInput(
+            placeholder="Session length (45 - 600 seconds)",
+            default="60",
+            min_length=1,
+            max_length=3
+        )
     )
 
     async def on_submit(self, interaction: discord.Interaction):
+        assert isinstance(self.nation.component, discord.ui.TextInput)
+        assert isinstance(self.recruitment_template.component, discord.ui.TextInput)
+        assert isinstance(self.session_length.component, discord.ui.TextInput)
+
+        nation = self.nation.component.value.strip().lower().replace(" ", "_")
+        template = self.recruitment_template.component.value.replace("%", "")
+
+        try:
+            session_length = int(self.session_length.component.value)
+        except ValueError:
+            raise Exception("Session length must be a number")
+        else:
+            if session_length < 45 or session_length > 600:
+                raise Exception("Session length must be between 45 and 600 seconds")
+
+        try:
+            founded_time = datetime.fromtimestamp(
+                int(
+                    (await self.bot.request(
+                        f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=foundedtime"))
+                    .find("FOUNDEDTIME")
+                    .text
+                )
+            )
+        except AttributeError:
+            raise NationNotFound(interaction.user, nation)
+
+        recruiter_id = await self.bot.get_recruiter_id(interaction.user, interaction.channel_id)
+
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:
-                nation = self.nation.value.strip().lower().replace(" ", "_")
-                template = self.recruitment_template.value.replace("%", "")
-
-                try:
-                    session_length = int(self.session_length.value)
-                except ValueError:
-                    raise Exception("Session length must be a number")
-
-                if session_length < 45 or session_length > 600:
-                    raise Exception("Session length must be between 45 and 600 seconds")
-
-                try:
-                    founded_time = datetime.fromtimestamp(
-                        int(
-                            (await self.bot.request(f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=foundedtime"))
-                            .find("FOUNDEDTIME")
-                            .text
-                        )
-                    )
-                except AttributeError:
-                    raise NationNotFound(interaction.user, nation)
-
-                recruiter_id = await self.bot.get_recruiter_id(interaction.user, interaction.channel_id)
-
                 if recruiter_id:
                     await cur.execute(
                         "UPDATE users SET nation = %s, recruitTemplate = %s, sessionLength = %s, foundedTime = %s WHERE id = %s;",
@@ -123,31 +155,70 @@ class ReportModal(Modal, title="Recruitment Report"):
         super().__init__(timeout=None)
         self.bot = bot
 
-    start_time = discord.ui.TextInput(
-        label="Start Time",
-        placeholder="YYYY-MM-DD HH:MM:SS",
-        default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        min_length=10,
-        max_length=19,
+    r_type = discord.ui.Label(
+        text="Report Type",
+        component=discord.ui.RadioGroup(
+            options=[
+                discord.RadioGroupOption(label="Default", value="default",
+                                         description="Telegram count with days active", default=True),
+                discord.RadioGroupOption(label="Count Only", value="count_only", description="Telegram count only"),
+                discord.RadioGroupOption(label="Streaks", value="streaks", description="Active recruitment streaks"),
+            ],
+            required=True
+        )
     )
 
-    end_time = discord.ui.TextInput(
-        label="End Time",
-        placeholder="YYYY-MM-DD HH:MM:SS",
-        default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        min_length=10,
-        max_length=19,
+    start_time = discord.ui.Label(
+        text="Start Time",
+        component=discord.ui.TextInput(
+            placeholder="YYYY-MM-DD HH:MM:SS",
+            default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            min_length=10,
+            max_length=19,
+        )
+    )
+
+    end_time = discord.ui.Label(
+        text="End Time",
+        component=discord.ui.TextInput(
+            placeholder="YYYY-MM-DD HH:MM:SS",
+            default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            min_length=10,
+            max_length=19,
+        )
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        start_time = datetime.fromisoformat(self.start_time.value).replace(tzinfo=timezone.utc)
-        end_time = datetime.fromisoformat(self.end_time.value).replace(tzinfo=timezone.utc)
+        assert isinstance(self.r_type.component, discord.ui.RadioGroup)
+        assert isinstance(self.start_time.component, discord.ui.TextInput)
+        assert isinstance(self.end_time.component, discord.ui.TextInput)
+
+        start_time = datetime.fromisoformat(self.start_time.component.value).replace(tzinfo=timezone.utc)
+        end_time = datetime.fromisoformat(self.end_time.component.value).replace(tzinfo=timezone.utc)
+        report_type = self.r_type.component.value
+
+        if report_type == "streaks":
+            result = await self.bot.get_streaks(start_time, end_time, interaction.channel_id)
+
+            if result:
+                resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
+            else:
+                resp = "No active streaks"
+            await interaction.response.send_message(
+                f"Recruitment Streaks: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```",
+                ephemeral=True
+            )
+            return
 
         result = await self.bot.get_telegrams(start_time, end_time, interaction.channel_id)
 
-        resp = "\n".join([f"{nation}: {count}" for nation, count in result])
+        if report_type == "count_only":
+            resp = "\n".join([f"{nation}: {count}" for nation, count, _days in result])
+        else:
+            resp = "\n".join([f"{nation}: {count} ({days}d)" for nation, count, days in result])
         await interaction.response.send_message(
-            f"Recruitment Report: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```", ephemeral=True
+            f"Recruitment Report: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```",
+            ephemeral=True
         )
 
     async def on_error(self, interation: discord.Interaction, error: Exception):
@@ -163,7 +234,8 @@ class RecruitView(View):
     @discord.ui.button(label="Recruit", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:recruit")
     async def recruit(self, interaction: discord.Interaction, _button: discord.ui.button):
         embed, view, delete_after = await self.bot.create_recruitment_response(interaction.user, interaction.channel_id)
-        view.message = await interaction.response.send_message(embed=embed, view=view, ephemeral=True, delete_after=3 + delete_after)
+        view.message = await interaction.response.send_message(embed=embed, view=view, ephemeral=True,
+                                                               delete_after=3 + delete_after)
         await self.bot.update_status_embeds(interaction.channel_id)
 
     @discord.ui.button(label="Register", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:register")
@@ -254,9 +326,11 @@ class RecruitmentCog(commands.Cog):
         if not interaction.channel_id:
             raise app_commands.AppCommandError("command must be run in a channel")
 
-        global_whitelist, local_whitelist = map("\n".join, self.bot.queue_manager.list_whitelist(interaction.channel_id))
+        global_whitelist, local_whitelist = map("\n".join,
+                                                self.bot.queue_manager.list_whitelist(interaction.channel_id))
 
-        await interaction.response.send_message(f"**Global**{global_whitelist}**Local**{local_whitelist}", ephemeral=True)
+        await interaction.response.send_message(f"**Global**{global_whitelist}**Local**{local_whitelist}",
+                                                ephemeral=True)
 
     admin_command_group = app_commands.Group(name="admin", description="global bot administrator commands")
 

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -119,7 +119,7 @@ class RegisterRecruiterModal(Modal, title="Registration"):
                 await interaction.response.send_message("Registration complete!", ephemeral=True, delete_after=10)
 
     async def on_error(self, interation: discord.Interaction, error: Exception):
-        self.bot.std.error(error)
+        logger.error(error)
         await interation.response.send_message(f"An error occurred: {error}", ephemeral=True)
 
 

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -28,20 +28,21 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        if self.is_finished() and self.region.value != "":
+        if self.is_finished() and self.region.value == "":
             raise ValueError("Region cannot be empty")
 
         assert isinstance(self.region.component, discord.ui.TextInput)
 
         region = self.region.component.value.strip().lower().replace(" ", "_")
-                # Check if channel is already registered in the database
+
+        async with self.bot.pool.acquire() as conn:
+            async with conn.cursor() as cur:
                 await cur.execute(
                     "SELECT id FROM recruitment_channels WHERE channelId = %s;",
                     (interaction.channel.id,),
                 )
 
                 if await cur.fetchone():
-                    # Channel exists in DB but may not be loaded in memory — reload it
                     if interaction.channel.id not in self.bot.queue_manager._queues:
                         await cur.execute(
                             "SELECT region FROM exceptions WHERE channelId = (SELECT id FROM recruitment_channels WHERE channelId = %s);",
@@ -61,10 +62,6 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
 
                 message = await interaction.channel.send(view=RecruitView(self.bot))
 
-        message = await interaction.channel.send(view=RecruitView(self.bot))
-
-        async with self.bot.pool.acquire() as conn:
-            async with conn.cursor() as cur:
                 try:
                     await cur.execute(
                         "INSERT INTO recruitment_channels (serverId, channelId, messageId) VALUES (%s, %s, %s);",

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -378,14 +378,14 @@ class RecruitmentCog(commands.Cog):
     async def add_filter(self, interaction: discord.Interaction, pattern: str):
         await self.bot.queue_manager.add_global_filter(pattern)
 
-        await interaction.response.send_message(f"added global filter: ``{pattern}``", ephemeral=True)
+        await interaction.response.send_message(f"Added global filter: ``{pattern}``.", ephemeral=True)
 
     @filter_command_group.command(name="remove", description="remove a global name filter")
     @app_commands.check(is_global_admin)
     async def remove_filter(self, interaction: discord.Interaction, pattern: str):
         await self.bot.queue_manager.remove_global_filter(pattern)
 
-        await interaction.response.send_message(f"removed global filter: ``{pattern}``", ephemeral=True)
+        await interaction.response.send_message(f"Removed global filter: ``{pattern}``.", ephemeral=True)
 
 
 async def setup(bot: Bot):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -278,14 +278,14 @@ class RecruitmentCog(commands.Cog):
     async def add_filter(self, interaction: discord.Interaction, pattern: str):
         await self.bot.queue_manager.add_global_filter(pattern)
 
-        await interaction.response.send_message(f"added global filter: {pattern}", ephemeral=True)
+        await interaction.response.send_message(f"added global filter: ``{pattern}``", ephemeral=True)
 
     @filter_command_group.command(name="remove", description="remove a global name filter")
     @app_commands.check(is_global_admin)
     async def remove_filter(self, interaction: discord.Interaction, pattern: str):
         await self.bot.queue_manager.remove_global_filter(pattern)
 
-        await interaction.response.send_message(f"removed global filter: {pattern}", ephemeral=True)
+        await interaction.response.send_message(f"removed global filter: ``{pattern}``", ephemeral=True)
 
 
 async def setup(bot: Bot):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -45,7 +45,10 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
                 if await cur.fetchone():
                     if interaction.channel.id not in self.bot.queue_manager._queues:
                         await cur.execute(
-                            "SELECT region FROM exceptions WHERE channelId = (SELECT id FROM recruitment_channels WHERE channelId = %s);",
+                            """SELECT region
+                               FROM exceptions
+                                   JOIN recruitment_channels ON recruitment_channels.id = exceptions.channelId
+                               WHERE recruitment_channels.channelId = %s;""",
                             (interaction.channel.id,),
                         )
                         regions = [r[0] for r in await cur.fetchall()]

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -1,21 +1,16 @@
-import discord
 import logging
-
 from datetime import datetime, timezone
+
+import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 from discord.ui import Modal, View
 
-
 from components.bot import Bot
-from components.config.config_manager import configInstance
-from components.errors import WhitelistError, NationNotFound
+from components.checks import is_global_admin
+from components.errors import NationNotFound, WhitelistError
 
 logger = logging.getLogger("main")
-
-
-def is_global_admin(interaction: discord.Interaction) -> bool:
-    return interaction.user.id in configInstance.data.global_administrators
 
 
 class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel"):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -308,7 +308,7 @@ class RecruitmentCog(commands.Cog):
         guild = interaction.guild
 
         if not guild:
-            raise app_commands.AppCommandError("command must be run in a guild")
+            raise app_commands.AppCommandError("command must be run in a server")
 
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -271,6 +271,22 @@ class RecruitmentCog(commands.Cog):
 
         await interaction.response.send_message("all set!", ephemeral=True)
 
+    filter_command_group = app_commands.Group(name="filter", description="commands for managing global puppet filters")
+
+    @filter_command_group.command(name="add", description="add a global name filter")
+    @app_commands.check(is_global_admin)
+    async def add_filter(self, interaction: discord.Interaction, pattern: str):
+        await self.bot.queue_manager.add_global_filter(pattern)
+
+        await interaction.response.send_message(f"added global filter: {pattern}", ephemeral=True)
+
+    @filter_command_group.command(name="remove", description="remove a global name filter")
+    @app_commands.check(is_global_admin)
+    async def remove_filter(self, interaction: discord.Interaction, pattern: str):
+        await self.bot.queue_manager.remove_global_filter(pattern)
+
+        await interaction.response.send_message(f"removed global filter: {pattern}", ephemeral=True)
+
 
 async def setup(bot: Bot):
     await bot.add_cog(RecruitmentCog(bot))

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -259,7 +259,7 @@ class RecruitView(View):
         embed, view, delete_after = await self.bot.create_recruitment_response(interaction.user, interaction.channel_id)
         view.message = await interaction.response.send_message(embed=embed, view=view, ephemeral=True,
                                                                delete_after=3 + delete_after)
-        await self.bot.update_status_embeds(interaction.channel_id)
+        await self.bot.update_status_embed(interaction.channel_id)
 
     @discord.ui.button(label="Register", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:register")
     async def register(self, interaction: discord.Interaction, _button: discord.ui.button):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -210,14 +210,17 @@ class RecruitmentCog(commands.Cog):
     @app_commands.guild_only()
     @app_commands.checks.has_permissions(administrator=True)
     async def register_recruitment_channel(self, interaction: discord.Interaction):
-        assert interaction.guild is not None
+        guild = interaction.guild
+
+        if not guild:
+            raise app_commands.AppCommandError("command must be run in a guild")
 
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute("SELECT id FROM whitelist WHERE serverId = %s;", (interaction.guild.id,))
 
                 if not await cur.fetchone():
-                    raise WhitelistError(interaction.user, interaction.guild)
+                    raise WhitelistError(interaction.user, guild)
 
         await interaction.response.send_modal(RegisterRecruitmentChannelModal(self.bot))
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -310,7 +310,7 @@ class Bot(commands.Bot):
                         try:
                             channel = self.get_channel(channel_id)
 
-                            assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
+                            # assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
 
                             message = await channel.fetch_message(message_id)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -314,11 +314,15 @@ class Bot(commands.Bot):
                                 logger.warning("channel %d not found; skipping", channel_id)
                                 continue
 
-                            logger.debug("channel type: %s", type(channel))
+                            if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+                                logger.warning("Channel %d not found or wrong type (%s)", channel_id, type(channel))
+                                continue
 
-                            assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
-
-                            message = await channel.fetch_message(message_id)
+                            try:
+                                message = await channel.fetch_message(message_id)
+                            except discord.NotFound:
+                                logger.warning("message: %d not found, skipping", message_id)
+                                continue
 
                             await message.edit(embed=embed)
                         except Exception:

--- a/components/bot.py
+++ b/components/bot.py
@@ -259,7 +259,7 @@ class Bot(commands.Bot):
             discord.ui.Button(
                 label="Open Telegram",
                 style=discord.ButtonStyle.link,
-                url=f"https://fast.nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{recruiter.template}%25&generated_by=Asperta+Recruitment+Bot",
+                url=f"https://nationstates.net/page=compose_telegram?tgto={','.join(nations)}&message=%25{recruiter.template}%25&generated_by=Asperta+Recruitment+Bot",
             )
         )
 
@@ -310,7 +310,7 @@ class Bot(commands.Bot):
                         try:
                             channel = self.get_channel(channel_id)
 
-                            # assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
+                            assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
 
                             message = await channel.fetch_message(message_id)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -268,7 +268,10 @@ class Bot(commands.Bot):
     async def update_status_embeds(self, channel_id: Optional[int] = None):
         """Update status embeds. If `channel_id` is provided, only update the embed for that channel"""
 
-        logger.info("Updating status embeds")
+        if channel_id:
+            logger.info("updating status embed for channel %d", channel_id)
+        else:
+            logger.info("Updating status embeds")
 
         if channel_id:
             embed = discord.Embed(title="Recruitment Queue")
@@ -312,6 +315,5 @@ class Bot(commands.Bot):
                             message = await channel.fetch_message(message_id)
 
                             await message.edit(embed=embed)
-                        except Exception as e:
-                            logger.error("Error updating channel_id: %d", channel_id)
-                            logger.error(f"Error in update_loop: {e}")
+                        except Exception:
+                            logger.exception("error updating channel_id: %d", channel_id)

--- a/components/bot.py
+++ b/components/bot.py
@@ -310,6 +310,8 @@ class Bot(commands.Bot):
                         try:
                             channel = self.get_channel(channel_id)
 
+                            logging.info("%s", type(channel))
+
                             assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
 
                             message = await channel.fetch_message(message_id)

--- a/components/bot.py
+++ b/components/bot.py
@@ -310,7 +310,11 @@ class Bot(commands.Bot):
                         try:
                             channel = self.get_channel(channel_id)
 
-                            logging.info("%s", type(channel))
+                            if not channel:
+                                logger.warning("channel %d not found; skipping", channel_id)
+                                continue
+
+                            logger.debug("channel type: %s", type(channel))
 
                             assert isinstance(channel, discord.TextChannel) or isinstance(channel, discord.Thread)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -218,7 +218,8 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 await cur.execute(
                     """SELECT users.nation,
-                              SUM(nationCount) AS 'tgcount', COUNT(DISTINCT DATE (telegrams.timestamp)) AS 'days'
+                              SUM(nationCount)                          AS 'tgcount',
+                              COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
                        FROM telegrams
                                 JOIN users on users.id = telegrams.recruiterId
                        WHERE telegrams.timestamp BETWEEN %s AND %s
@@ -240,24 +241,25 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """WITH daily AS (SELECT telegrams.recruiterId, DATE (telegrams.timestamp) AS dt
-                       FROM telegrams
-                           JOIN users ON users.id = telegrams.recruiterId
-                           JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
-                       WHERE recruitment_channels.channelId = %s
-                       GROUP BY telegrams.recruiterId, DATE (telegrams.timestamp)),
-                           islands AS (
-                       SELECT recruiterId, dt, DATE_SUB(dt, INTERVAL
-                           ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
-                           DAY) AS island
-                       FROM daily)
-                    SELECT users.nation, COUNT(*) AS streak_days
-                    FROM islands
-                             JOIN users ON users.id = islands.recruiterId
-                    GROUP BY islands.recruiterId, islands.island
-                    HAVING MAX(dt) >= %s
-                       AND MIN(dt) <= %s
-                    ORDER BY streak_days DESC;
+                    """WITH daily AS (SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
+                                      FROM telegrams
+                                               JOIN users ON users.id = telegrams.recruiterId
+                                               JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
+                                      WHERE recruitment_channels.channelId = %s
+                                      GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)),
+                            islands AS (SELECT recruiterId,
+                                               dt,
+                                               DATE_SUB(dt, INTERVAL
+                                                        ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
+                                                        DAY) AS island
+                                        FROM daily)
+                       SELECT users.nation, COUNT(*) AS streak_days
+                       FROM islands
+                                JOIN users ON users.id = islands.recruiterId
+                       GROUP BY islands.recruiterId, islands.island
+                       HAVING MAX(dt) >= %s
+                          AND MIN(dt) <= %s
+                       ORDER BY streak_days DESC;
                     """,
                     (channel_id, start_time, end_time),
                 )

--- a/components/bot.py
+++ b/components/bot.py
@@ -333,4 +333,8 @@ class Bot(commands.Bot):
                     channels = await cur.fetchall()
 
                     for channel in channels:
-                        await self._update_status_embed(channel[0])
+                        if type(c_id := channel[0]) is not int:
+                            logger.warning("invalid type for channel_id: %d", type(channel_id))
+                            continue
+
+                        await self._update_status_embed(c_id)

--- a/components/bot.py
+++ b/components/bot.py
@@ -61,7 +61,6 @@ class Bot(commands.Bot):
 
     def __init__(self, session: aiohttp.ClientSession, ql: QueueManager, pool: aiomysql.Pool):
         intents = discord.Intents.default()
-        # intents.message_content = True
 
         super().__init__(command_prefix="!", intents=intents)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -243,11 +243,9 @@ class Bot(commands.Bot):
                 await cur.execute(
                     """WITH daily AS (SELECT telegrams.recruiterId, DATE (telegrams.timestamp) AS dt
                        FROM telegrams
-                           JOIN users
-                       ON users.id = telegrams.recruiterId
-                       WHERE telegrams.channelId = (SELECT id
-                           FROM recruitment_channels
-                           WHERE channelId = %s)
+                           JOIN users ON users.id = telegrams.recruiterId
+                           JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
+                       WHERE recruitment_channels.channelId = %s
                        GROUP BY telegrams.recruiterId, DATE (telegrams.timestamp)),
                            islands AS (
                        SELECT recruiterId, dt, DATE_SUB(dt, INTERVAL

--- a/components/bot.py
+++ b/components/bot.py
@@ -61,11 +61,12 @@ class Bot(commands.Bot):
 
     def __init__(self, session: aiohttp.ClientSession, ql: QueueManager, pool: aiomysql.Pool):
         intents = discord.Intents.default()
-        intents.message_content = True
+        # intents.message_content = True
 
         super().__init__(command_prefix="!", intents=intents)
 
-        self._headers = {"User-Agent": f"Aperta Recruitment Bot, developed by nation=upc, run by {configInstance.data.operator}"}
+        self._headers = {
+            "User-Agent": f"Aperta Recruitment Bot, developed by nation=upc, run by {configInstance.data.operator}"}
         self._session = session
         self._pool = pool
         self._ratelimit = None
@@ -138,12 +139,12 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 num = await cur.execute(
-                    """SELECT id 
-                    FROM users 
-                    WHERE discordId = %s 
-                    AND channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    );""",
+                    """SELECT id
+                       FROM users
+                       WHERE discordId = %s
+                         AND channelId = (SELECT id
+                                          FROM recruitment_channels
+                                          WHERE channelId = %s);""",
                     (user.id, channel_id),
                 )
 
@@ -157,11 +158,11 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 num = await cur.execute(
                     """SELECT id, nation, recruitTemplate, allowRecruitmentAt, foundedTime
-                    FROM users
-                    WHERE discordId = %s
-                    AND channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    );
+                       FROM users
+                       WHERE discordId = %s
+                         AND channelId = (SELECT id
+                                          FROM recruitment_channels
+                                          WHERE channelId = %s);
                     """,
                     (user.id, channel_id),
                 )
@@ -190,8 +191,8 @@ class Bot(commands.Bot):
 
                 await cur.execute(
                     """UPDATE users
-                    SET allowRecruitmentAt = %s
-                    WHERE id = %s;
+                       SET allowRecruitmentAt = %s
+                       WHERE id = %s;
                     """,
                     (next_recruitment_timestamp, recruiter.id),
                 )
@@ -203,9 +204,9 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 await cur.execute(
                     """INSERT INTO telegrams (recruiterId, nationCount, channelId)
-                    VALUES (%s, %s, (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    ));
+                       VALUES (%s, %s, (SELECT id
+                                        FROM recruitment_channels
+                                        WHERE channelId = %s));
                     """,
                     (recruiter.id, nation_count, recruiter.channel_id),
                 )
@@ -217,17 +218,52 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """SELECT users.nation, SUM(nationCount) AS 'tgcount'
-                    FROM telegrams
-                    JOIN users on users.id = telegrams.recruiterId
-                    WHERE telegrams.timestamp BETWEEN %s AND %s
-                    AND telegrams.channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    )
-                    GROUP BY users.id 
-                    ORDER BY tgcount DESC;
+                    """SELECT users.nation,
+                              SUM(nationCount)                          AS 'tgcount',
+                              COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
+                       FROM telegrams
+                                JOIN users on users.id = telegrams.recruiterId
+                       WHERE telegrams.timestamp BETWEEN %s AND %s
+                         AND telegrams.channelId = (SELECT id
+                                                    FROM recruitment_channels
+                                                    WHERE channelId = %s)
+                       GROUP BY users.id
+                       ORDER BY tgcount DESC;
                     """,
                     (start_time, end_time, channel_id),
+                )
+
+                return await cur.fetchall()
+
+    async def get_streaks(self, start_time: datetime, end_time: datetime, channel_id: int):
+        if start_time > end_time:
+            raise Exception("Start time must be before end time")
+
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """WITH daily AS (SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
+                                      FROM telegrams
+                                               JOIN users ON users.id = telegrams.recruiterId
+                                      WHERE telegrams.channelId = (SELECT id
+                                                                   FROM recruitment_channels
+                                                                   WHERE channelId = %s)
+                                      GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)),
+                            islands AS (SELECT recruiterId,
+                                               dt,
+                                               DATE_SUB(dt, INTERVAL
+                                                        ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
+                                                        DAY) AS island
+                                        FROM daily)
+                       SELECT users.nation, COUNT(*) AS streak_days
+                       FROM islands
+                                JOIN users ON users.id = islands.recruiterId
+                       GROUP BY islands.recruiterId, islands.island
+                       HAVING MAX(dt) >= %s
+                          AND MIN(dt) <= %s
+                       ORDER BY streak_days DESC;
+                    """,
+                    (channel_id, start_time, end_time),
                 )
 
                 return await cur.fetchall()
@@ -250,7 +286,8 @@ class Bot(commands.Bot):
         await self.update_telegram_count(recruiter, len(nations))
 
         embed = discord.Embed(title="Recruit", color=int("2d0001", 16))
-        embed.add_field(name="Nations", value="\n".join([f"https://www.nationstates.net/nation={nation}" for nation in nations]))
+        embed.add_field(name="Nations",
+                        value="\n".join([f"https://www.nationstates.net/nation={nation}" for nation in nations]))
         embed.add_field(name="Template", value=f"```{recruiter.template}```", inline=False)
         embed.set_footer(text=f"Initiated by {recruiter.nation} at {datetime.now(timezone.utc).strftime('%H:%M:%S')}")
 
@@ -293,7 +330,8 @@ class Bot(commands.Bot):
 
         embed = discord.Embed(title="Recruitment Queue")
         embed.add_field(name="Nations in Queue", value=self._queue_list.get_nation_count(channel_id))
-        embed.add_field(name="Last Updated", value=f"<t:{int(self._queue_list.channel(channel_id).last_updated.timestamp())}:R>")
+        embed.add_field(name="Last Updated",
+                        value=f"<t:{int(self._queue_list.channel(channel_id).last_updated.timestamp())}:R>")
 
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
@@ -320,7 +358,9 @@ class Bot(commands.Bot):
                     logger.warning("unspecified error while retrieving message %d: %s", message_id, e)
                     return
 
-                await message.edit(embed=embed)
+                from cogs.recruit import RecruitView
+
+                await message.edit(embed=embed, view=RecruitView(self))
 
     async def update_status_embeds(self, channel_id: Optional[int] = None):
         """Update status embeds. If `channel_id` is provided, only update the embed for that channel"""

--- a/components/bot.py
+++ b/components/bot.py
@@ -157,12 +157,11 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 num = await cur.execute(
-                    """SELECT id, nation, recruitTemplate, allowRecruitmentAt, foundedTime
+                    """SELECT users.id, nation, recruitTemplate, allowRecruitmentAt, foundedTime
                        FROM users
-                       WHERE discordId = %s
-                         AND channelId = (SELECT id
-                                          FROM recruitment_channels
-                                          WHERE channelId = %s);
+                           JOIN recruitment_channels ON recruitment_channels.id = users.channelId
+                       WHERE users.discordId = %s
+                         AND recruitment_channels.channelId = %s;
                     """,
                     (user.id, channel_id),
                 )

--- a/components/bot.py
+++ b/components/bot.py
@@ -288,65 +288,49 @@ class Bot(commands.Bot):
 
         return None
 
+    async def _update_status_embed(self, channel_id: int):
+        logger.info("updating status embed for channel %d", channel_id)
+
+        embed = discord.Embed(title="Recruitment Queue")
+        embed.add_field(name="Nations in Queue", value=self._queue_list.get_nation_count(channel_id))
+        embed.add_field(name="Last Updated", value=f"<t:{int(self._queue_list.channel(channel_id).last_updated.timestamp())}:R>")
+
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT messageId FROM recruitment_channels WHERE channelId = %s;", channel_id)
+
+                message_id = (await cur.fetchone())[0]
+
+                if type(message_id) is not int:
+                    logger.warning("invalid type for message_id: %d", type(message_id))
+                    return
+
+                channel = await self.resolve_channel(channel_id)
+
+                if not channel:
+                    logger.warning("unable to resolve channel %d", channel_id)
+                    return
+
+                try:
+                    message = await channel.fetch_message(message_id)
+                except discord.NotFound:
+                    logger.warning("message: %d not found, skipping", message_id)
+                    return
+                except Exception as e:
+                    logger.warning("unspecified error while retrieving message %d: %s", message_id, e)
+                    return
+
+                await message.edit(embed=embed)
+
     async def update_status_embeds(self, channel_id: Optional[int] = None):
         """Update status embeds. If `channel_id` is provided, only update the embed for that channel"""
-
         if channel_id:
-            logger.info("updating status embed for channel %d", channel_id)
-        else:
-            logger.info("Updating status embeds")
-
-        if channel_id:
-            embed = discord.Embed(title="Recruitment Queue")
-            embed.add_field(name="Nations in Queue", value=self._queue_list.get_nation_count(channel_id))
-            embed.add_field(name="Last Updated", value=f"<t:{int(self._queue_list.channel(channel_id).last_updated.timestamp())}:R>")
-
-            async with self._pool.acquire() as conn:
-                async with conn.cursor() as cur:
-                    await cur.execute("SELECT messageId FROM recruitment_channels WHERE channelId = %s;", channel_id)
-
-                    message_id = (await cur.fetchone())[0]
-
-                    if type(message_id) is not int:
-                        logger.warning("invalid type for message_id: %d", type(message_id))
-                        return
-
-                    channel = await self.resolve_channel(channel_id)
-
-                    if not channel:
-                        return
-
-                    message = await channel.fetch_message(message_id)
-
-                    await message.edit(embed=embed)
-
+            await self._update_status_embed(channel_id)
         else:
             async with self._pool.acquire() as conn:
                 async with conn.cursor() as cur:
-                    await cur.execute("SELECT channelId, messageId FROM recruitment_channels;")
-                    recruitment_views = await cur.fetchall()
+                    await cur.execute("SELECT channelId FROM recruitment_channels;")
+                    channels = await cur.fetchall()
 
-                    for channel_id, message_id in recruitment_views:
-                        if type(channel_id) is not int or type(message_id) is not int:
-                            logger.warning("invalid type for channel_id: %d, message_id: %d", type(channel_id), type(message_id))
-                            continue
-
-                        embed = discord.Embed(title="Recruitment Queue")
-                        embed.add_field(name="Nations in Queue", value=self._queue_list.get_nation_count(channel_id))
-                        embed.add_field(name="Last Updated", value=f"<t:{int(datetime.now().timestamp())}:R>")
-
-                        try:
-                            channel = await self.resolve_channel(channel_id)
-
-                            if not channel:
-                                continue
-
-                            try:
-                                message = await channel.fetch_message(message_id)
-                            except discord.NotFound:
-                                logger.warning("message: %d not found, skipping", message_id)
-                                continue
-
-                            await message.edit(embed=embed)
-                        except Exception:
-                            logger.exception("error updating channel_id: %d", channel_id)
+                    for channel in channels:
+                        await self._update_status_embed(channel[0])

--- a/components/bot.py
+++ b/components/bot.py
@@ -52,7 +52,7 @@ class Bot(commands.Bot):
     @property
     def request_timestamps(self) -> List[datetime]:
         """A list of timestamps for each request made in the current NS API bucket"""
-        return self.request_timestamps
+        return self._request_timestamps
 
     @property
     def queue_manager(self) -> QueueManager:

--- a/components/bot.py
+++ b/components/bot.py
@@ -219,8 +219,7 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 await cur.execute(
                     """SELECT users.nation,
-                              SUM(nationCount)                          AS 'tgcount',
-                              COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
+                              SUM(nationCount) AS 'tgcount', COUNT(DISTINCT DATE (telegrams.timestamp)) AS 'days'
                        FROM telegrams
                                 JOIN users on users.id = telegrams.recruiterId
                        WHERE telegrams.timestamp BETWEEN %s AND %s
@@ -242,26 +241,26 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """WITH daily AS (SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
-                                      FROM telegrams
-                                               JOIN users ON users.id = telegrams.recruiterId
-                                      WHERE telegrams.channelId = (SELECT id
-                                                                   FROM recruitment_channels
-                                                                   WHERE channelId = %s)
-                                      GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)),
-                            islands AS (SELECT recruiterId,
-                                               dt,
-                                               DATE_SUB(dt, INTERVAL
-                                                        ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
-                                                        DAY) AS island
-                                        FROM daily)
-                       SELECT users.nation, COUNT(*) AS streak_days
-                       FROM islands
-                                JOIN users ON users.id = islands.recruiterId
-                       GROUP BY islands.recruiterId, islands.island
-                       HAVING MAX(dt) >= %s
-                          AND MIN(dt) <= %s
-                       ORDER BY streak_days DESC;
+                    """WITH daily AS (SELECT telegrams.recruiterId, DATE (telegrams.timestamp) AS dt
+                       FROM telegrams
+                           JOIN users
+                       ON users.id = telegrams.recruiterId
+                       WHERE telegrams.channelId = (SELECT id
+                           FROM recruitment_channels
+                           WHERE channelId = %s)
+                       GROUP BY telegrams.recruiterId, DATE (telegrams.timestamp)),
+                           islands AS (
+                       SELECT recruiterId, dt, DATE_SUB(dt, INTERVAL
+                           ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
+                           DAY) AS island
+                       FROM daily)
+                    SELECT users.nation, COUNT(*) AS streak_days
+                    FROM islands
+                             JOIN users ON users.id = islands.recruiterId
+                    GROUP BY islands.recruiterId, islands.island
+                    HAVING MAX(dt) >= %s
+                       AND MIN(dt) <= %s
+                    ORDER BY streak_days DESC;
                     """,
                     (channel_id, start_time, end_time),
                 )
@@ -325,7 +324,7 @@ class Bot(commands.Bot):
 
         return None
 
-    async def _update_status_embed(self, channel_id: int):
+    async def update_status_embed(self, channel_id: int):
         logger.info("updating status embed for channel %d", channel_id)
 
         embed = discord.Embed(title="Recruitment Queue")
@@ -362,19 +361,15 @@ class Bot(commands.Bot):
 
                 await message.edit(embed=embed, view=RecruitView(self))
 
-    async def update_status_embeds(self, channel_id: Optional[int] = None):
-        """Update status embeds. If `channel_id` is provided, only update the embed for that channel"""
-        if channel_id:
-            await self._update_status_embed(channel_id)
-        else:
-            async with self._pool.acquire() as conn:
-                async with conn.cursor() as cur:
-                    await cur.execute("SELECT channelId FROM recruitment_channels;")
-                    channels = await cur.fetchall()
+    async def update_status_embeds(self):
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT channelId FROM recruitment_channels;")
+                channels = await cur.fetchall()
 
-                    for channel in channels:
-                        if type(c_id := channel[0]) is not int:
-                            logger.warning("invalid type for channel_id: %d", type(channel_id))
-                            continue
+                for channel in channels:
+                    if type(channel_id := channel[0]) is not int:
+                        logger.warning("invalid type for channel_id: %s", type(channel_id))
+                        continue
 
-                        await self._update_status_embed(c_id)
+                    await self.update_status_embed(channel_id)

--- a/components/bot.py
+++ b/components/bot.py
@@ -1,12 +1,12 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
 import aiohttp
 import aiomysql
 import discord
-import logging
-
 from bs4 import BeautifulSoup as bs
-from datetime import datetime, timedelta, timezone
 from discord.ext import commands
-from typing import List, Optional
 
 from components.config.config_manager import configInstance
 from components.errors import LastRecruitmentTooRecent, NotRegistered, TooManyRequests
@@ -307,7 +307,9 @@ class Bot(commands.Bot):
 
                     message_id = (await cur.fetchone())[0]
 
-                    assert isinstance(message_id, int)
+                    if type(message_id) is not int:
+                        logger.warning("invalid type for message_id: %d", type(message_id))
+                        return
 
                     channel = await self.resolve_channel(channel_id)
 
@@ -325,7 +327,9 @@ class Bot(commands.Bot):
                     recruitment_views = await cur.fetchall()
 
                     for channel_id, message_id in recruitment_views:
-                        assert type(channel_id) is int and type(message_id) is int
+                        if type(channel_id) is not int or type(message_id) is not int:
+                            logger.warning("invalid type for channel_id: %d, message_id: %d", type(channel_id), type(message_id))
+                            continue
 
                         embed = discord.Embed(title="Recruitment Queue")
                         embed.add_field(name="Nations in Queue", value=self._queue_list.get_nation_count(channel_id))

--- a/components/bot.py
+++ b/components/bot.py
@@ -139,12 +139,11 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 num = await cur.execute(
-                    """SELECT id
+                    """SELECT users.id
                        FROM users
-                       WHERE discordId = %s
-                         AND channelId = (SELECT id
-                                          FROM recruitment_channels
-                                          WHERE channelId = %s);""",
+                           JOIN recruitment_channels ON recruitment_channels.id = users.channelId
+                       WHERE users.discordId = %s
+                         AND recruitment_channels.channelId = %s;""",
                     (user.id, channel_id),
                 )
 
@@ -220,11 +219,10 @@ class Bot(commands.Bot):
                     """SELECT users.nation,
                               SUM(nationCount) AS 'tgcount', COUNT(DISTINCT DATE (telegrams.timestamp)) AS 'days'
                        FROM telegrams
-                                JOIN users on users.id = telegrams.recruiterId
+                                JOIN users ON users.id = telegrams.recruiterId
+                                JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
                        WHERE telegrams.timestamp BETWEEN %s AND %s
-                         AND telegrams.channelId = (SELECT id
-                                                    FROM recruitment_channels
-                                                    WHERE channelId = %s)
+                         AND recruitment_channels.channelId = %s
                        GROUP BY users.id
                        ORDER BY tgcount DESC;
                     """,

--- a/components/checks.py
+++ b/components/checks.py
@@ -1,6 +1,12 @@
 import discord
+from discord.ext import commands
 
 from components.config.config_manager import configInstance
 
+
 def is_global_admin(interaction: discord.Interaction) -> bool:
     return interaction.user.id in configInstance.data.global_administrators
+
+
+def is_global_admin_text(ctx: commands.Context) -> bool:
+    return ctx.author.id in configInstance.data.global_administrators

--- a/components/checks.py
+++ b/components/checks.py
@@ -1,0 +1,6 @@
+import discord
+
+from components.config.config_manager import configInstance
+
+def is_global_admin(interaction: discord.Interaction) -> bool:
+    return interaction.user.id in configInstance.data.global_administrators

--- a/components/queue.py
+++ b/components/queue.py
@@ -304,8 +304,12 @@ class QueueManager(AbstractAsyncContextManager):
         logger.info("starting update thread")
 
         with httpx.Client(headers=HEADERS, timeout=None) as client:
-            for event in sse_retrying(client, "GET", "https://www.nationstates.net/api/founding+move"):
-                self._handle_event(event)
+            while True:
+                try:
+                    for event in sse_retrying(client, "GET", "https://www.nationstates.net/api/founding+move"):
+                        self._handle_event(event)
+                except Exception:
+                    logger.exception("error in SSE feed")
 
 
 def sse_retrying(client, method, url):

--- a/components/queue.py
+++ b/components/queue.py
@@ -69,9 +69,12 @@ class Queue:
     _nations: List[Nation]
     _last_updated: datetime
 
-    def __init__(self, whitelist: List[str] = []):
+    def __init__(self, whitelist=None):
+        if whitelist is None:
+            whitelist = []
         self._nations = []
         self._whitelist = whitelist
+        self._last_updated = datetime.now(timezone.utc)
 
     def __repr__(self):
         return f"<Queue nations={len(self._nations)}>"

--- a/components/queue.py
+++ b/components/queue.py
@@ -167,7 +167,10 @@ class QueueManager(AbstractAsyncContextManager):
 
                 for channel in channels:
                     await cur.execute(
-                        "SELECT region FROM exceptions WHERE channelId = (SELECT id FROM recruitment_channels WHERE channelId = %s);",
+                        """SELECT region
+                           FROM exceptions
+                               JOIN recruitment_channels ON recruitment_channels.id = exceptions.channelId
+                           WHERE recruitment_channels.channelId = %s;""",
                         (channel,),
                     )
 

--- a/components/queue.py
+++ b/components/queue.py
@@ -1,22 +1,21 @@
-import aiomysql
 import asyncio
-import discord
-import httpx
 import json
 import logging
 import re
 import threading
 import time
-
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from httpx_sse import connect_sse, ServerSentEvent
 from typing import List, Self
+
+import aiomysql
+import discord
+import httpx
+from httpx_sse import ServerSentEvent, connect_sse
 from stamina import retry
 
 from components.errors import EmptyQueue
-
 
 logger = logging.getLogger("main")
 
@@ -140,6 +139,8 @@ class QueueManager(AbstractAsyncContextManager):
     _pool: aiomysql.Pool
     _queues: dict[int, Queue] = field(default_factory=dict)
     _queue_lock: threading.Lock
+    _filters: List[re.Pattern]
+    _filter_lock: threading.Lock
     _update_thread: threading.Thread
     _running: bool
 
@@ -148,12 +149,14 @@ class QueueManager(AbstractAsyncContextManager):
         self._pool = pool
         self._queues = {}
         self._queue_lock = threading.Lock()
+        self._filters = []
+        self._filter_lock = threading.Lock()
         self._running = True
 
     def __repr__(self):
         return f"<QueueList queues={self._queues}>"
 
-    async def __aenter__(self):
+    async def _init_channels(self):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute("SELECT channelId FROM recruitment_channels;")
@@ -173,6 +176,18 @@ class QueueManager(AbstractAsyncContextManager):
                 regions: List[str] = [line[0] for line in await cur.fetchall()]
 
                 self._whitelist = regions
+
+    async def _init_filters(self):
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT pattern FROM filters;")
+
+                with self._filter_lock:
+                    self._filters = [re.compile(resp[0]) for resp in await cur.fetchall()]
+
+    async def __aenter__(self):
+        await self._init_channels()
+        await self._init_filters()
 
         self._update_thread = threading.Thread(target=self._update, daemon=True)
 
@@ -247,6 +262,52 @@ class QueueManager(AbstractAsyncContextManager):
     def list_whitelist(self, channel_id: int):
         return (self._whitelist, self._queues[channel_id].whitelist)
 
+    async def add_global_filter(self, pattern: str):
+        try:
+            new_filter = re.compile(pattern)
+        except re.error as e:
+            logger.error("invalid regex: %s", pattern)
+            raise e
+        else:
+            if new_filter in self._filters:
+                logger.warning("filter already exists: %s", pattern)
+                return
+
+            with self._filter_lock:
+                self._filters.append(new_filter)
+
+            await self._db_insert_filter(pattern)
+
+    async def _db_insert_filter(self, pattern: str):
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("INSERT INTO filters (pattern) VALUES (%s);", (pattern,))
+
+    async def remove_global_filter(self, pattern: str):
+        try:
+            filter_to_remove = re.compile(pattern)
+        except re.error as e:
+            logger.error("invalid regex: %s", pattern)
+            raise e
+        else:
+            if filter_to_remove not in self._filters:
+                logger.warning("filter does not exist: %s", pattern)
+                return
+
+            with self._filter_lock:
+                self._filters.remove(filter_to_remove)
+
+            await self._db_remove_filter(pattern)
+
+    async def _db_remove_filter(self, pattern: str):
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("DELETE FROM filters WHERE pattern = %s;", (pattern,))
+
+    def _is_filtered(self, nation: str) -> bool:
+        with self._filter_lock:
+            return any(nation_filter.match(nation) for nation_filter in self._filters)
+
     def channel(self, channel_id: int) -> Queue:
         with self._queue_lock:
             return self._queues[channel_id]
@@ -264,7 +325,7 @@ class QueueManager(AbstractAsyncContextManager):
             return self._queues[channel_id].get_nation_count()
 
     def _handle_founding(self, event: FoundingEvent):
-        if PUPPET_REGEX.match(event.nation):
+        if self._is_filtered(event.nation):
             logger.debug("likely puppet founding found; skipping: %s", event.nation)
             return
 
@@ -277,7 +338,7 @@ class QueueManager(AbstractAsyncContextManager):
                 queue.handle_founding(Nation(event.nation, event.region, event.timestamp.astimezone(timezone.utc)))
 
     def _handle_move(self, event: MoveEvent):
-        if PUPPET_REGEX.match(event.nation):
+        if self._is_filtered(event.nation):
             logger.debug("likely puppet move found; skipping: %s", event.nation)
             return
 

--- a/components/queue.py
+++ b/components/queue.py
@@ -301,15 +301,15 @@ class QueueManager(AbstractAsyncContextManager):
         except re.error as e:
             logger.error("invalid regex: %s", pattern)
             raise e
-        else:
-            if filter_to_remove not in self._filters:
-                logger.warning("filter does not exist: %s", pattern)
-                return
 
-            with self._filter_lock:
-                self._filters.remove(filter_to_remove)
+        if filter_to_remove not in self._filters:
+            logger.warning("filter does not exist: %s", pattern)
+            return
 
-            await self._db_remove_filter(pattern)
+        with self._filter_lock:
+            self._filters.remove(filter_to_remove)
+
+        await self._db_remove_filter(pattern)
 
     async def _db_remove_filter(self, pattern: str):
         async with self._pool.acquire() as conn:

--- a/components/queue.py
+++ b/components/queue.py
@@ -19,7 +19,8 @@ from components.errors import EmptyQueue
 
 logger = logging.getLogger("main")
 
-PUPPET_REGEX = re.compile(r"^\d+_[a-z0-9_]+|[a-z0-9_]+_\d+$|^[a-z0-9_]+_m{0,4}(?:cm|cd|d?c{0,3})(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})$")
+PUPPET_REGEX = re.compile(
+    r"^\d+_[a-z0-9_]+|[a-z0-9_]+_\d+$|^[a-z0-9_]+_m{0,4}(?:cm|cd|d?c{0,3})(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})$")
 FOUNDING_REGEX = re.compile("^@@([a-z0-9_]+)@@ was founded in %%([a-z0-9_]+)%%.?$")
 MOVE_REGEX = re.compile("^@@([a-z0-9_]+)@@ relocated from %%([a-z0-9_]+)%% to %%([a-z0-9_]+)%%.?$")
 
@@ -104,7 +105,8 @@ class Queue:
     def prune(self):
         current_time = datetime.now(timezone.utc)
 
-        self._nations = [nation for nation in self._nations if (current_time - nation.founding_time).total_seconds() < 3600]
+        self._nations = [nation for nation in self._nations if
+                         (current_time - nation.founding_time).total_seconds() < 3600]
 
     def purge(self):
         self._nations = []
@@ -169,7 +171,7 @@ class QueueManager(AbstractAsyncContextManager):
                     await cur.execute(
                         """SELECT region
                            FROM exceptions
-                               JOIN recruitment_channels ON recruitment_channels.id = exceptions.channelId
+                                    JOIN recruitment_channels ON recruitment_channels.id = exceptions.channelId
                            WHERE recruitment_channels.channelId = %s;""",
                         (channel,),
                     )
@@ -246,9 +248,8 @@ class QueueManager(AbstractAsyncContextManager):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """INSERT INTO exceptions (channelId, region) VALUES (
-                        (SELECT id FROM recruitment_channels WHERE channelId = %s), %s
-                    );""",
+                    """INSERT INTO exceptions (channelId, region)
+                       VALUES ((SELECT id FROM recruitment_channels WHERE channelId = %s), %s);""",
                     (channel_id, region),
                 )
 
@@ -263,9 +264,12 @@ class QueueManager(AbstractAsyncContextManager):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """DELETE FROM exceptions WHERE region = %s AND channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    );""",
+                    """DELETE
+                       FROM exceptions
+                       WHERE region = %s
+                         AND channelId = (SELECT id
+                                          FROM recruitment_channels
+                                          WHERE channelId = %s);""",
                     (region, channel_id),
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ dependencies = [
     "urllib3==1.26.15",
     "yarl==1.9.3",
 ]
+
+[tool.uv]
+exclude-newer = "2 weeks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pymysql==1.1.0",
     "python-dateutil==2.8.2",
     "python-dotenv==1.0.0",
+    "ruff>=0.15.7",
     "six==1.16.0",
     "soupsieve==2.4",
     "stamina>=25.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "httpx>=0.28.1",
     "httpx-sse>=0.4.3",
     "idna==3.4",
+    "lxml>=6.0.2",
     "marshmallow==3.19.0",
     "marshmallow-enum==1.5.1",
     "multidict==6.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "cron-converter==1.0.2",
     "cryptography==44.0.0",
     "dataclasses-json==0.5.7",
-    "discord-py>=2.6.4",
+    "discord-py>=2.7.0",
     "frozenlist==1.4.1",
     "httpx>=0.28.1",
     "httpx-sse>=0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -497,6 +497,7 @@ dependencies = [
     { name = "pymysql" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
+    { name = "ruff" },
     { name = "six" },
     { name = "soupsieve" },
     { name = "stamina" },
@@ -539,6 +540,7 @@ requires-dist = [
     { name = "pymysql", specifier = "==1.1.0" },
     { name = "python-dateutil", specifier = "==2.8.2" },
     { name = "python-dotenv", specifier = "==1.0.0" },
+    { name = "ruff", specifier = ">=0.15.7" },
     { name = "six", specifier = "==1.16.0" },
     { name = "soupsieve", specifier = "==2.4" },
     { name = "stamina", specifier = ">=25.2.0" },
@@ -546,6 +548,31 @@ requires-dist = [
     { name = "typing-inspect", specifier = "==0.8.0" },
     { name = "urllib3", specifier = "==1.26.15" },
     { name = "yarl", specifier = "==1.9.3" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -319,6 +319,50 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
+    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
+    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
+]
+
+[[package]]
 name = "marshmallow"
 version = "3.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -442,6 +486,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "idna" },
+    { name = "lxml" },
     { name = "marshmallow" },
     { name = "marshmallow-enum" },
     { name = "multidict" },
@@ -483,6 +528,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "idna", specifier = "==3.4" },
+    { name = "lxml", specifier = ">=6.0.2" },
     { name = "marshmallow", specifier = "==3.19.0" },
     { name = "marshmallow-enum", specifier = "==1.5.1" },
     { name = "multidict", specifier = "==6.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -243,15 +243,15 @@ wheels = [
 
 [[package]]
 name = "discord-py"
-version = "2.6.4"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "audioop-lts" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/9b1dbb9b2fc07616132a526c05af23cfd420381793968a189ee08e12e35f/discord_py-2.6.4.tar.gz", hash = "sha256:44384920bae9b7a073df64ae9b14c8cf85f9274b5ad5d1d07bd5a67539de2da9", size = 1092623, upload-time = "2025-10-08T21:45:43.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/57/9a2d9abdabdc9db8ef28ce0cf4129669e1c8717ba28d607b5ba357c4de3b/discord_py-2.7.1.tar.gz", hash = "sha256:24d5e6a45535152e4b98148a9dd6b550d25dc2c9fb41b6d670319411641249da", size = 1106326, upload-time = "2026-03-03T18:40:46.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/ae/3d3a89b06f005dc5fa8618528dde519b3ba7775c365750f7932b9831ef05/discord_py-2.6.4-py3-none-any.whl", hash = "sha256:2783b7fb7f8affa26847bfc025144652c294e8fe6e0f8877c67ed895749eb227", size = 1209284, upload-time = "2025-10-08T21:45:41.679Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/17208c3b3f92319e7fad259f1c6d5a5baf8fd0654c54846ced329f83c3eb/discord_py-2.7.1-py3-none-any.whl", hash = "sha256:849dca2c63b171146f3a7f3f8acc04248098e9e6203412ce3cf2745f284f7439", size = 1227550, upload-time = "2026-03-03T18:40:44.492Z" },
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ requires-dist = [
     { name = "cron-converter", specifier = "==1.0.2" },
     { name = "cryptography", specifier = "==44.0.0" },
     { name = "dataclasses-json", specifier = "==0.5.7" },
-    { name = "discord-py", specifier = ">=2.6.4" },
+    { name = "discord-py", specifier = ">=2.7.0" },
     { name = "frozenlist", specifier = "==1.4.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.3" },


### PR DESCRIPTION
This branch is still in testing, but I wanted to get ahead while I had some free time and open a PR. The key feature here is runtime defined nation name filters. 

We held off on implementing something like this for a long time, because our attitude was  that it was better to recruit these nations manually and avoid wasting stamps and/or API recruitment on them. Recent discussions both internally and with our partners have demonstrated some recruiter fatigue around these nations, though, and we've generally come to agree that it is worth removing these nations from the manual queue. 

This PR replaces the global ``PUPPET_REGEX`` defined in components/queue.py with a ``_filters`` attribute on the ``QueueManager`` class. ``_filters`` is a list of compiled ``re.Pattern``s. These patterns are stored in a new database table. Existing patterns are initialized in the ``QueueManager``'s ``__aenter__`` call, alongside the list of recruitment channels. Filters can be modified at runtime by a global admin (Darc, Rand, upc) using the ``/filter add`` and ``/filter remove`` commands. The former checks that the pattern is a valid regex, and prevents the addition of duplicate patterns. A command to list filters would be a good later addition. 

We also discussed granting individual regions the ability to define custom filters. We can definitely consider this, but I'd like to get this feature out while we have that discussion.