### PR TITLE
Fix errors in whitelist add command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ config.json
 queue.txt
 .run/Start Bot.run.xml
 .DS_Store
+schema.sql

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -7,7 +7,7 @@ from components.bot import Bot
 
 def is_authorized():
     def predicate(ctx: commands.Context):
-        if ctx.author.id not in [230778695713947648, 110600636319440896]:
+        if ctx.author.id not in [230778695713947648, 110600636319440896, 134499733849899008]:
             raise commands.MissingPermissions(["Bot Administrator"])
 
         return True

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -33,6 +33,31 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
             async with conn.cursor() as cur:
                 region = self.region.value.strip().lower().replace(" ", "_")
 
+                # Check if channel is already registered in the database
+                await cur.execute(
+                    "SELECT id FROM recruitment_channels WHERE channelId = %s;",
+                    (interaction.channel.id,),
+                )
+
+                if await cur.fetchone():
+                    # Channel exists in DB but may not be loaded in memory — reload it
+                    if interaction.channel.id not in self.bot.queue_manager._queues:
+                        await cur.execute(
+                            "SELECT region FROM exceptions WHERE channelId = (SELECT id FROM recruitment_channels WHERE channelId = %s);",
+                            (interaction.channel.id,),
+                        )
+                        regions = [r[0] for r in await cur.fetchall()]
+                        self.bot.queue_manager.add_channel(interaction.channel.id, regions)
+                        await interaction.response.send_message(
+                            f"Channel was already registered but not loaded. Reloaded with regions: {', '.join(regions)}",
+                            ephemeral=True,
+                        )
+                    else:
+                        await interaction.response.send_message(
+                            "This channel is already registered as a recruitment channel.", ephemeral=True
+                        )
+                    return
+
                 message = await interaction.channel.send(view=RecruitView(self.bot))
 
                 try:
@@ -235,7 +260,7 @@ class RecruitmentCog(commands.Cog):
 
         await self.bot.queue_manager.add_to_channel_whitelist(interaction.channel_id, region)
 
-        await interaction.response.send_message(f"region: {region: } added to whitelist", ephemeral=True)
+        await interaction.response.send_message(f"region: {region} added to whitelist", ephemeral=True)
 
     @whitelist_command_group.command(name="remove", description="remove a region from this channel's ignore list")
     @app_commands.checks.has_permissions(administrator=True)

--- a/components/queue.py
+++ b/components/queue.py
@@ -1,6 +1,7 @@
 import aiomysql
 import asyncio
 import discord
+from discord import app_commands
 import httpx
 import json
 import logging
@@ -207,13 +208,19 @@ class QueueManager(AbstractAsyncContextManager):
 
             self._whitelist.remove(region)
 
+    def _get_channel_queue(self, channel_id: int) -> Queue:
+        try:
+            return self._queues[channel_id]
+        except KeyError:
+            raise app_commands.AppCommandError("This channel is not registered as a recruitment channel.")
+
     async def add_to_channel_whitelist(self, channel_id: int, region: str):
         region = region.strip().lower().replace(" ", "_")
 
         if region in self._whitelist:
             return
 
-        if region in self._queues[channel_id].whitelist:
+        if region in self._get_channel_queue(channel_id).whitelist:
             return
 
         async with self._pool.acquire() as conn:
@@ -225,12 +232,12 @@ class QueueManager(AbstractAsyncContextManager):
                     (channel_id, region),
                 )
 
-        self._queues[channel_id].whitelist.append(region)
+        self._get_channel_queue(channel_id).whitelist.append(region)
 
     async def remove_from_channel_whitelist(self, channel_id: int, region: str):
         region = region.strip().lower().replace(" ", "_")
 
-        if region not in self._queues[channel_id].whitelist:
+        if region not in self._get_channel_queue(channel_id).whitelist:
             return
 
         async with self._pool.acquire() as conn:
@@ -242,10 +249,10 @@ class QueueManager(AbstractAsyncContextManager):
                     (region, channel_id),
                 )
 
-        self._queues[channel_id].whitelist.remove(region)
+        self._get_channel_queue(channel_id).whitelist.remove(region)
 
     def list_whitelist(self, channel_id: int):
-        return (self._whitelist, self._queues[channel_id].whitelist)
+        return (self._whitelist, self._get_channel_queue(channel_id).whitelist)
 
     def channel(self, channel_id: int) -> Queue:
         with self._queue_lock:


### PR DESCRIPTION
- Fixed an edge case KeyError where sometimes the recruitment channel is registered but not loaded into memory; added safety checks for channel registration status
- Fixed an edge case KeyError where sometimes the recruitment channel is registered but the queue is not loaded into memory; added a method that handles the error
- Fixed a ValueError when returning the result of the /whitelist add command due to a typo in the Python string formatter
- Certified works on my machine