### PR TITLE
Consistency awards & streaks

### DIFF
--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -18,18 +18,27 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
         super().__init__(timeout=None)
         self.bot = bot
 
-    region = discord.ui.TextInput(label="Region", min_length=1, max_length=40)
+    region = discord.ui.Label(
+        text="Region",
+        component=discord.ui.TextInput(
+            placeholder="Enter your region name",
+            min_length=1,
+            max_length=40,
+        )
+    )
 
     async def on_submit(self, interaction: discord.Interaction):
         if self.is_finished() and self.region.value != "":
             raise ValueError("Region cannot be empty")
 
+        assert isinstance(self.region.component, discord.ui.TextInput)
+
+        region = self.region.component.value.strip().lower().replace(" ", "_")
+
+        message = await interaction.channel.send(view=RecruitView(self.bot))
+
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:
-                region = self.region.value.strip().lower().replace(" ", "_")
-
-                message = await interaction.channel.send(view=RecruitView(self.bot))
-
                 try:
                     await cur.execute(
                         "INSERT INTO recruitment_channels (serverId, channelId, messageId) VALUES (%s, %s, %s);",

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -123,12 +123,16 @@ class ReportModal(Modal, title="Recruitment Report"):
         super().__init__(timeout=None)
         self.bot = bot
 
-    report_type = discord.ui.RadioGroup(
-        options=[
-            discord.RadioGroupOption(label="Default", value="default", description="Telegram count with days active", default=True),
-            discord.RadioGroupOption(label="Count Only", value="count_only", description="Telegram count only"),
-            discord.RadioGroupOption(label="Streaks", value="streaks", description="Active recruitment streaks"),
-        ],
+    r_type = discord.ui.Label(
+        text="Report Type",
+        component=discord.ui.RadioGroup(
+            options=[
+                discord.RadioGroupOption(
+                    label="Streaks"
+                )
+            ],
+            required=True
+        )
     )
 
     start_time = discord.ui.TextInput(

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -138,27 +138,36 @@ class ReportModal(Modal, title="Recruitment Report"):
         )
     )
 
-    start_time = discord.ui.TextInput(
-        label="Start Time",
-        placeholder="YYYY-MM-DD HH:MM:SS",
-        default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        min_length=10,
-        max_length=19,
+    start_time = discord.ui.Label(
+        text="Start Time",
+        component=discord.ui.TextInput(
+            placeholder="YYYY-MM-DD HH:MM:SS",
+            default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            min_length=10,
+            max_length=19,
+        )
     )
 
-    end_time = discord.ui.TextInput(
-        label="End Time",
-        placeholder="YYYY-MM-DD HH:MM:SS",
-        default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        min_length=10,
-        max_length=19,
+    end_time = discord.ui.Label(
+        text="End Time",
+        component=discord.ui.TextInput(
+            placeholder="YYYY-MM-DD HH:MM:SS",
+            default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            min_length=10,
+            max_length=19,
+        )
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        start_time = datetime.fromisoformat(self.start_time.value).replace(tzinfo=timezone.utc)
-        end_time = datetime.fromisoformat(self.end_time.value).replace(tzinfo=timezone.utc)
+        assert isinstance(self.r_type.component, discord.ui.RadioGroup)
+        assert isinstance(self.start_time.component, discord.ui.TextInput)
+        assert isinstance(self.end_time.component, discord.ui.TextInput)
 
-        if self.r_type.component.value == "streaks":
+        start_time = datetime.fromisoformat(self.start_time.component.value).replace(tzinfo=timezone.utc)
+        end_time = datetime.fromisoformat(self.end_time.component.value).replace(tzinfo=timezone.utc)
+        report_type = self.r_type.component.value
+
+        if report_type == "streaks":
             result = await self.bot.get_streaks(start_time, end_time, interaction.channel_id)
 
             if result:
@@ -166,13 +175,14 @@ class ReportModal(Modal, title="Recruitment Report"):
             else:
                 resp = "No active streaks"
             await interaction.response.send_message(
-                f"Recruitment Streaks: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```", ephemeral=True
+                f"Recruitment Streaks: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```",
+                ephemeral=True
             )
             return
 
         result = await self.bot.get_telegrams(start_time, end_time, interaction.channel_id)
 
-        if self.r_type.component.value == "count_only":
+        if report_type == "count_only":
             resp = "\n".join([f"{nation}: {count}" for nation, count, _days in result])
         else:
             resp = "\n".join([f"{nation}: {count} ({days}d)" for nation, count, days in result])

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -119,9 +119,10 @@ class RegisterRecruiterModal(Modal, title="Registration"):
 
 
 class ReportModal(Modal, title="Recruitment Report"):
-    def __init__(self, bot: Bot):
+    def __init__(self, bot: Bot, count_only: bool = False):
         super().__init__(timeout=None)
         self.bot = bot
+        self.count_only = count_only
 
     start_time = discord.ui.TextInput(
         label="Start Time",
@@ -145,7 +146,10 @@ class ReportModal(Modal, title="Recruitment Report"):
 
         result = await self.bot.get_telegrams(start_time, end_time, interaction.channel_id)
 
-        resp = "\n".join([f"{nation}: {count}" for nation, count in result])
+        if self.count_only:
+            resp = "\n".join([f"{nation}: {count}" for nation, count, _days in result])
+        else:
+            resp = "\n".join([f"{nation}: {count} ({days}d)" for nation, count, days in result])
         await interaction.response.send_message(
             f"Recruitment Report: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```", ephemeral=True
         )
@@ -154,6 +158,29 @@ class ReportModal(Modal, title="Recruitment Report"):
         logger.error(error)
         await interation.response.send_message(f"An error occurred: {error}", ephemeral=True)
 
+
+class ReportTypeView(View):
+    def __init__(self, bot: Bot):
+        super().__init__(timeout=60)
+        self.bot = bot
+
+    @discord.ui.button(label="Default", style=discord.ButtonStyle.blurple)
+    async def default_report(self, interaction: discord.Interaction, _button: discord.ui.button):
+        await interaction.response.send_modal(ReportModal(self.bot, count_only=False))
+
+    @discord.ui.button(label="Count Only", style=discord.ButtonStyle.grey)
+    async def count_only_report(self, interaction: discord.Interaction, _button: discord.ui.button):
+        await interaction.response.send_modal(ReportModal(self.bot, count_only=True))
+
+    @discord.ui.button(label="Streaks", style=discord.ButtonStyle.green)
+    async def streaks_report(self, interaction: discord.Interaction, _button: discord.ui.button):
+        result = await self.bot.get_streaks(interaction.channel_id)
+
+        if result:
+            resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
+        else:
+            resp = "No active streaks"
+        await interaction.response.send_message(f"Active Recruitment Streaks\n```{resp}```", ephemeral=True)
 
 class RecruitView(View):
     def __init__(self, bot: Bot):
@@ -172,17 +199,7 @@ class RecruitView(View):
 
     @discord.ui.button(label="Report", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:report")
     async def report(self, interaction: discord.Interaction, _button: discord.ui.button):
-        await interaction.response.send_modal(ReportModal(self.bot))
-
-    @discord.ui.button(label="Streaks", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:streaks")
-    async def streaks(self, interaction: discord.Interaction, _button: discord.ui.button):
-        result = await self.bot.get_streaks(interaction.channel_id)
-
-        if result:
-            resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
-        else:
-            resp = "No active streaks"
-        await interaction.response.send_message(f"Active Recruitment Streaks\n```{resp}```", ephemeral=True)
+        await interaction.response.send_message("Select a report type:", view=ReportTypeView(self.bot), ephemeral=True)
 
     async def on_error(self, interaction: discord.Interaction, error: Exception, _item: discord.ui.Item):
         logger.error(error)

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -60,45 +60,66 @@ class RegisterRecruiterModal(Modal, title="Registration"):
         super().__init__(timeout=None)
         self.bot = bot
 
-    nation = discord.ui.TextInput(label="Nation", placeholder="Enter your nation name", min_length=3, max_length=40)
-
-    recruitment_template = discord.ui.TextInput(
-        label="Recruitment Template", placeholder="Enter your recruitment template", min_length=10, max_length=20
+    nation = discord.ui.Label(
+        text="Nation",
+        component=discord.ui.TextInput(
+            placeholder="Enter your nation name",
+            min_length=3,
+            max_length=40,
+        )
     )
 
-    session_length = discord.ui.TextInput(
-        label="Session Length (in seconds)", placeholder="Session length (45 - 600 seconds)", default="60",
-        min_length=1, max_length=3
+    recruitment_template = discord.ui.Label(
+        text="Recruitment Template",
+        component=discord.ui.TextInput(
+            placeholder="Enter your recruitment template",
+            min_length=10,
+            max_length=20,
+        )
+    )
+
+    session_length = discord.ui.Label(
+        text="Session Length (in seconds)",
+        component=discord.ui.TextInput(
+            placeholder="Session length (45 - 600 seconds)",
+            default="60",
+            min_length=1,
+            max_length=3
+        )
     )
 
     async def on_submit(self, interaction: discord.Interaction):
+        assert isinstance(self.nation.component, discord.ui.TextInput)
+        assert isinstance(self.recruitment_template.component, discord.ui.TextInput)
+        assert isinstance(self.session_length.component, discord.ui.TextInput)
+
+        nation = self.nation.component.value.strip().lower().replace(" ", "_")
+        template = self.recruitment_template.component.value.replace("%", "")
+
+        try:
+            session_length = int(self.session_length.component.value)
+        except ValueError:
+            raise Exception("Session length must be a number")
+        else:
+            if session_length < 45 or session_length > 600:
+                raise Exception("Session length must be between 45 and 600 seconds")
+
+        try:
+            founded_time = datetime.fromtimestamp(
+                int(
+                    (await self.bot.request(
+                        f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=foundedtime"))
+                    .find("FOUNDEDTIME")
+                    .text
+                )
+            )
+        except AttributeError:
+            raise NationNotFound(interaction.user, nation)
+
+        recruiter_id = await self.bot.get_recruiter_id(interaction.user, interaction.channel_id)
+
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:
-                nation = self.nation.value.strip().lower().replace(" ", "_")
-                template = self.recruitment_template.value.replace("%", "")
-
-                try:
-                    session_length = int(self.session_length.value)
-                except ValueError:
-                    raise Exception("Session length must be a number")
-
-                if session_length < 45 or session_length > 600:
-                    raise Exception("Session length must be between 45 and 600 seconds")
-
-                try:
-                    founded_time = datetime.fromtimestamp(
-                        int(
-                            (await self.bot.request(
-                                f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=foundedtime"))
-                            .find("FOUNDEDTIME")
-                            .text
-                        )
-                    )
-                except AttributeError:
-                    raise NationNotFound(interaction.user, nation)
-
-                recruiter_id = await self.bot.get_recruiter_id(interaction.user, interaction.channel_id)
-
                 if recruiter_id:
                     await cur.execute(
                         "UPDATE users SET nation = %s, recruitTemplate = %s, sessionLength = %s, foundedTime = %s WHERE id = %s;",

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -119,10 +119,17 @@ class RegisterRecruiterModal(Modal, title="Registration"):
 
 
 class ReportModal(Modal, title="Recruitment Report"):
-    def __init__(self, bot: Bot, count_only: bool = False):
+    def __init__(self, bot: Bot):
         super().__init__(timeout=None)
         self.bot = bot
-        self.count_only = count_only
+
+    report_type = discord.ui.RadioGroup(
+        options=[
+            discord.RadioGroupOption(label="Default", value="default", description="Telegram count with days active", default=True),
+            discord.RadioGroupOption(label="Count Only", value="count_only", description="Telegram count only"),
+            discord.RadioGroupOption(label="Streaks", value="streaks", description="Active recruitment streaks"),
+        ],
+    )
 
     start_time = discord.ui.TextInput(
         label="Start Time",
@@ -141,12 +148,22 @@ class ReportModal(Modal, title="Recruitment Report"):
     )
 
     async def on_submit(self, interaction: discord.Interaction):
+        if self.report_type.value == "streaks":
+            result = await self.bot.get_streaks(interaction.channel_id)
+
+            if result:
+                resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
+            else:
+                resp = "No active streaks"
+            await interaction.response.send_message(f"Active Recruitment Streaks\n```{resp}```", ephemeral=True)
+            return
+
         start_time = datetime.fromisoformat(self.start_time.value).replace(tzinfo=timezone.utc)
         end_time = datetime.fromisoformat(self.end_time.value).replace(tzinfo=timezone.utc)
 
         result = await self.bot.get_telegrams(start_time, end_time, interaction.channel_id)
 
-        if self.count_only:
+        if self.report_type.value == "count_only":
             resp = "\n".join([f"{nation}: {count}" for nation, count, _days in result])
         else:
             resp = "\n".join([f"{nation}: {count} ({days}d)" for nation, count, days in result])
@@ -158,29 +175,6 @@ class ReportModal(Modal, title="Recruitment Report"):
         logger.error(error)
         await interation.response.send_message(f"An error occurred: {error}", ephemeral=True)
 
-
-class ReportTypeView(View):
-    def __init__(self, bot: Bot):
-        super().__init__(timeout=60)
-        self.bot = bot
-
-    @discord.ui.button(label="Default", style=discord.ButtonStyle.blurple)
-    async def default_report(self, interaction: discord.Interaction, _button: discord.ui.button):
-        await interaction.response.send_modal(ReportModal(self.bot, count_only=False))
-
-    @discord.ui.button(label="Count Only", style=discord.ButtonStyle.grey)
-    async def count_only_report(self, interaction: discord.Interaction, _button: discord.ui.button):
-        await interaction.response.send_modal(ReportModal(self.bot, count_only=True))
-
-    @discord.ui.button(label="Streaks", style=discord.ButtonStyle.green)
-    async def streaks_report(self, interaction: discord.Interaction, _button: discord.ui.button):
-        result = await self.bot.get_streaks(interaction.channel_id)
-
-        if result:
-            resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
-        else:
-            resp = "No active streaks"
-        await interaction.response.send_message(f"Active Recruitment Streaks\n```{resp}```", ephemeral=True)
 
 class RecruitView(View):
     def __init__(self, bot: Bot):
@@ -199,7 +193,7 @@ class RecruitView(View):
 
     @discord.ui.button(label="Report", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:report")
     async def report(self, interaction: discord.Interaction, _button: discord.ui.button):
-        await interaction.response.send_message("Select a report type:", view=ReportTypeView(self.bot), ephemeral=True)
+        await interaction.response.send_modal(ReportModal(self.bot))
 
     async def on_error(self, interaction: discord.Interaction, error: Exception, _item: discord.ui.Item):
         logger.error(error)

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -174,6 +174,16 @@ class RecruitView(View):
     async def report(self, interaction: discord.Interaction, _button: discord.ui.button):
         await interaction.response.send_modal(ReportModal(self.bot))
 
+    @discord.ui.button(label="Streaks", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:streaks")
+    async def streaks(self, interaction: discord.Interaction, _button: discord.ui.button):
+        result = await self.bot.get_streaks(interaction.channel_id)
+
+        if result:
+            resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
+        else:
+            resp = "No active streaks"
+        await interaction.response.send_message(f"Active Recruitment Streaks\n```{resp}```", ephemeral=True)
+
     async def on_error(self, interaction: discord.Interaction, error: Exception, _item: discord.ui.Item):
         logger.error(error)
         await interaction.response.send_message(f"An error occurred: {error}", ephemeral=True)

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -127,9 +127,10 @@ class ReportModal(Modal, title="Recruitment Report"):
         text="Report Type",
         component=discord.ui.RadioGroup(
             options=[
-                discord.RadioGroupOption(
-                    label="Streaks"
-                )
+                discord.RadioGroupOption(label="Default", value="default",
+                                         description="Telegram count with days active", default=True),
+                discord.RadioGroupOption(label="Count Only", value="count_only", description="Telegram count only"),
+                discord.RadioGroupOption(label="Streaks", value="streaks", description="Active recruitment streaks"),
             ],
             required=True
         )

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -153,7 +153,7 @@ class ReportModal(Modal, title="Recruitment Report"):
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        if self.report_type.value == "streaks":
+        if self.r_type.component.value == "streaks":
             result = await self.bot.get_streaks(interaction.channel_id)
 
             if result:
@@ -168,7 +168,7 @@ class ReportModal(Modal, title="Recruitment Report"):
 
         result = await self.bot.get_telegrams(start_time, end_time, interaction.channel_id)
 
-        if self.report_type.value == "count_only":
+        if self.r_type.component.value == "count_only":
             resp = "\n".join([f"{nation}: {count}" for nation, count, _days in result])
         else:
             resp = "\n".join([f"{nation}: {count} ({days}d)" for nation, count, days in result])

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -67,7 +67,8 @@ class RegisterRecruiterModal(Modal, title="Registration"):
     )
 
     session_length = discord.ui.TextInput(
-        label="Session Length (in seconds)", placeholder="Session length (45 - 600 seconds)", default="60", min_length=1, max_length=3
+        label="Session Length (in seconds)", placeholder="Session length (45 - 600 seconds)", default="60",
+        min_length=1, max_length=3
     )
 
     async def on_submit(self, interaction: discord.Interaction):
@@ -87,7 +88,8 @@ class RegisterRecruiterModal(Modal, title="Registration"):
                 try:
                     founded_time = datetime.fromtimestamp(
                         int(
-                            (await self.bot.request(f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=foundedtime"))
+                            (await self.bot.request(
+                                f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=foundedtime"))
                             .find("FOUNDEDTIME")
                             .text
                         )
@@ -175,7 +177,8 @@ class ReportModal(Modal, title="Recruitment Report"):
         else:
             resp = "\n".join([f"{nation}: {count} ({days}d)" for nation, count, days in result])
         await interaction.response.send_message(
-            f"Recruitment Report: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```", ephemeral=True
+            f"Recruitment Report: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```",
+            ephemeral=True
         )
 
     async def on_error(self, interation: discord.Interaction, error: Exception):
@@ -191,7 +194,8 @@ class RecruitView(View):
     @discord.ui.button(label="Recruit", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:recruit")
     async def recruit(self, interaction: discord.Interaction, _button: discord.ui.button):
         embed, view, delete_after = await self.bot.create_recruitment_response(interaction.user, interaction.channel_id)
-        view.message = await interaction.response.send_message(embed=embed, view=view, ephemeral=True, delete_after=3 + delete_after)
+        view.message = await interaction.response.send_message(embed=embed, view=view, ephemeral=True,
+                                                               delete_after=3 + delete_after)
         await self.bot.update_status_embeds(interaction.channel_id)
 
     @discord.ui.button(label="Register", style=discord.ButtonStyle.blurple, custom_id="recruitment_view:register")
@@ -282,9 +286,11 @@ class RecruitmentCog(commands.Cog):
         if not interaction.channel_id:
             raise app_commands.AppCommandError("command must be run in a channel")
 
-        global_whitelist, local_whitelist = map("\n".join, self.bot.queue_manager.list_whitelist(interaction.channel_id))
+        global_whitelist, local_whitelist = map("\n".join,
+                                                self.bot.queue_manager.list_whitelist(interaction.channel_id))
 
-        await interaction.response.send_message(f"**Global**{global_whitelist}**Local**{local_whitelist}", ephemeral=True)
+        await interaction.response.send_message(f"**Global**{global_whitelist}**Local**{local_whitelist}",
+                                                ephemeral=True)
 
     admin_command_group = app_commands.Group(name="admin", description="global bot administrator commands")
 

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -153,18 +153,20 @@ class ReportModal(Modal, title="Recruitment Report"):
     )
 
     async def on_submit(self, interaction: discord.Interaction):
+        start_time = datetime.fromisoformat(self.start_time.value).replace(tzinfo=timezone.utc)
+        end_time = datetime.fromisoformat(self.end_time.value).replace(tzinfo=timezone.utc)
+
         if self.r_type.component.value == "streaks":
-            result = await self.bot.get_streaks(interaction.channel_id)
+            result = await self.bot.get_streaks(start_time, end_time, interaction.channel_id)
 
             if result:
                 resp = "\n".join([f"{nation}: {days} day{'s' if days != 1 else ''}" for nation, days in result])
             else:
                 resp = "No active streaks"
-            await interaction.response.send_message(f"Active Recruitment Streaks\n```{resp}```", ephemeral=True)
+            await interaction.response.send_message(
+                f"Recruitment Streaks: <t:{int(start_time.timestamp())}:f> to <t:{int(end_time.timestamp())}:f>\n```{resp}```", ephemeral=True
+            )
             return
-
-        start_time = datetime.fromisoformat(self.start_time.value).replace(tzinfo=timezone.utc)
-        end_time = datetime.fromisoformat(self.end_time.value).replace(tzinfo=timezone.utc)
 
         result = await self.bot.get_telegrams(start_time, end_time, interaction.channel_id)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -233,7 +233,10 @@ class Bot(commands.Bot):
 
                 return await cur.fetchall()
 
-    async def get_streaks(self, channel_id: int):
+    async def get_streaks(self, start_time: datetime, end_time: datetime, channel_id: int):
+        if start_time > end_time:
+            raise Exception("Start time must be before end time")
+
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
@@ -255,10 +258,10 @@ class Bot(commands.Bot):
                     FROM islands
                     JOIN users ON users.id = islands.recruiterId
                     GROUP BY islands.recruiterId, islands.island
-                    HAVING MAX(dt) >= CURDATE() - INTERVAL 1 DAY
+                    HAVING MAX(dt) >= %s AND MIN(dt) <= %s
                     ORDER BY streak_days DESC;
                     """,
-                    (channel_id,),
+                    (channel_id, start_time, end_time),
                 )
 
                 return await cur.fetchall()

--- a/components/bot.py
+++ b/components/bot.py
@@ -217,14 +217,15 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """SELECT users.nation, SUM(nationCount) AS 'tgcount'
+                    """SELECT users.nation, SUM(nationCount) AS 'tgcount',
+                    COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
                     FROM telegrams
                     JOIN users on users.id = telegrams.recruiterId
                     WHERE telegrams.timestamp BETWEEN %s AND %s
                     AND telegrams.channelId = (
                         SELECT id FROM recruitment_channels WHERE channelId = %s
                     )
-                    GROUP BY users.id 
+                    GROUP BY users.id
                     ORDER BY tgcount DESC;
                     """,
                     (start_time, end_time, channel_id),

--- a/components/bot.py
+++ b/components/bot.py
@@ -61,11 +61,12 @@ class Bot(commands.Bot):
 
     def __init__(self, session: aiohttp.ClientSession, ql: QueueManager, pool: aiomysql.Pool):
         intents = discord.Intents.default()
-        intents.message_content = True
+        # intents.message_content = True
 
         super().__init__(command_prefix="!", intents=intents)
 
-        self._headers = {"User-Agent": f"Aperta Recruitment Bot, developed by nation=upc, run by {configInstance.data.operator}"}
+        self._headers = {
+            "User-Agent": f"Aperta Recruitment Bot, developed by nation=upc, run by {configInstance.data.operator}"}
         self._session = session
         self._pool = pool
         self._ratelimit = None
@@ -138,12 +139,12 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 num = await cur.execute(
-                    """SELECT id 
-                    FROM users 
-                    WHERE discordId = %s 
-                    AND channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    );""",
+                    """SELECT id
+                       FROM users
+                       WHERE discordId = %s
+                         AND channelId = (SELECT id
+                                          FROM recruitment_channels
+                                          WHERE channelId = %s);""",
                     (user.id, channel_id),
                 )
 
@@ -157,11 +158,11 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 num = await cur.execute(
                     """SELECT id, nation, recruitTemplate, allowRecruitmentAt, foundedTime
-                    FROM users
-                    WHERE discordId = %s
-                    AND channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    );
+                       FROM users
+                       WHERE discordId = %s
+                         AND channelId = (SELECT id
+                                          FROM recruitment_channels
+                                          WHERE channelId = %s);
                     """,
                     (user.id, channel_id),
                 )
@@ -190,8 +191,8 @@ class Bot(commands.Bot):
 
                 await cur.execute(
                     """UPDATE users
-                    SET allowRecruitmentAt = %s
-                    WHERE id = %s;
+                       SET allowRecruitmentAt = %s
+                       WHERE id = %s;
                     """,
                     (next_recruitment_timestamp, recruiter.id),
                 )
@@ -203,9 +204,9 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 await cur.execute(
                     """INSERT INTO telegrams (recruiterId, nationCount, channelId)
-                    VALUES (%s, %s, (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    ));
+                       VALUES (%s, %s, (SELECT id
+                                        FROM recruitment_channels
+                                        WHERE channelId = %s));
                     """,
                     (recruiter.id, nation_count, recruiter.channel_id),
                 )
@@ -217,16 +218,17 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """SELECT users.nation, SUM(nationCount) AS 'tgcount',
-                    COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
-                    FROM telegrams
-                    JOIN users on users.id = telegrams.recruiterId
-                    WHERE telegrams.timestamp BETWEEN %s AND %s
-                    AND telegrams.channelId = (
-                        SELECT id FROM recruitment_channels WHERE channelId = %s
-                    )
-                    GROUP BY users.id
-                    ORDER BY tgcount DESC;
+                    """SELECT users.nation,
+                              SUM(nationCount)                          AS 'tgcount',
+                              COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
+                       FROM telegrams
+                                JOIN users on users.id = telegrams.recruiterId
+                       WHERE telegrams.timestamp BETWEEN %s AND %s
+                         AND telegrams.channelId = (SELECT id
+                                                    FROM recruitment_channels
+                                                    WHERE channelId = %s)
+                       GROUP BY users.id
+                       ORDER BY tgcount DESC;
                     """,
                     (start_time, end_time, channel_id),
                 )
@@ -240,26 +242,26 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """WITH daily AS (
-                        SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
-                        FROM telegrams
-                        JOIN users ON users.id = telegrams.recruiterId
-                        WHERE telegrams.channelId = (
-                            SELECT id FROM recruitment_channels WHERE channelId = %s
-                        )
-                        GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)
-                    ),
-                    islands AS (
-                        SELECT recruiterId, dt,
-                               DATE_SUB(dt, INTERVAL ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt) DAY) AS island
-                        FROM daily
-                    )
-                    SELECT users.nation, COUNT(*) AS streak_days
-                    FROM islands
-                    JOIN users ON users.id = islands.recruiterId
-                    GROUP BY islands.recruiterId, islands.island
-                    HAVING MAX(dt) >= %s AND MIN(dt) <= %s
-                    ORDER BY streak_days DESC;
+                    """WITH daily AS (SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
+                                      FROM telegrams
+                                               JOIN users ON users.id = telegrams.recruiterId
+                                      WHERE telegrams.channelId = (SELECT id
+                                                                   FROM recruitment_channels
+                                                                   WHERE channelId = %s)
+                                      GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)),
+                            islands AS (SELECT recruiterId,
+                                               dt,
+                                               DATE_SUB(dt, INTERVAL
+                                                        ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
+                                                        DAY) AS island
+                                        FROM daily)
+                       SELECT users.nation, COUNT(*) AS streak_days
+                       FROM islands
+                                JOIN users ON users.id = islands.recruiterId
+                       GROUP BY islands.recruiterId, islands.island
+                       HAVING MAX(dt) >= %s
+                          AND MIN(dt) <= %s
+                       ORDER BY streak_days DESC;
                     """,
                     (channel_id, start_time, end_time),
                 )
@@ -284,7 +286,8 @@ class Bot(commands.Bot):
         await self.update_telegram_count(recruiter, len(nations))
 
         embed = discord.Embed(title="Recruit", color=int("2d0001", 16))
-        embed.add_field(name="Nations", value="\n".join([f"https://www.nationstates.net/nation={nation}" for nation in nations]))
+        embed.add_field(name="Nations",
+                        value="\n".join([f"https://www.nationstates.net/nation={nation}" for nation in nations]))
         embed.add_field(name="Template", value=f"```{recruiter.template}```", inline=False)
         embed.set_footer(text=f"Initiated by {recruiter.nation} at {datetime.now(timezone.utc).strftime('%H:%M:%S')}")
 
@@ -327,7 +330,8 @@ class Bot(commands.Bot):
 
         embed = discord.Embed(title="Recruitment Queue")
         embed.add_field(name="Nations in Queue", value=self._queue_list.get_nation_count(channel_id))
-        embed.add_field(name="Last Updated", value=f"<t:{int(self._queue_list.channel(channel_id).last_updated.timestamp())}:R>")
+        embed.add_field(name="Last Updated",
+                        value=f"<t:{int(self._queue_list.channel(channel_id).last_updated.timestamp())}:R>")
 
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:

--- a/components/bot.py
+++ b/components/bot.py
@@ -232,6 +232,36 @@ class Bot(commands.Bot):
 
                 return await cur.fetchall()
 
+    async def get_streaks(self, channel_id: int):
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """WITH daily AS (
+                        SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
+                        FROM telegrams
+                        JOIN users ON users.id = telegrams.recruiterId
+                        WHERE telegrams.channelId = (
+                            SELECT id FROM recruitment_channels WHERE channelId = %s
+                        )
+                        GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)
+                    ),
+                    islands AS (
+                        SELECT recruiterId, dt,
+                               DATE_SUB(dt, INTERVAL ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt) DAY) AS island
+                        FROM daily
+                    )
+                    SELECT users.nation, COUNT(*) AS streak_days
+                    FROM islands
+                    JOIN users ON users.id = islands.recruiterId
+                    GROUP BY islands.recruiterId, islands.island
+                    HAVING MAX(dt) >= CURDATE() - INTERVAL 1 DAY
+                    ORDER BY streak_days DESC;
+                    """,
+                    (channel_id,),
+                )
+
+                return await cur.fetchall()
+
     async def create_recruitment_response(self, user: discord.User, channel_id: int):
         from cogs.recruit import TelegramView
 
@@ -320,7 +350,9 @@ class Bot(commands.Bot):
                     logger.warning("unspecified error while retrieving message %d: %s", message_id, e)
                     return
 
-                await message.edit(embed=embed)
+                from cogs.recruit import RecruitView
+
+                await message.edit(embed=embed, view=RecruitView(self))
 
     async def update_status_embeds(self, channel_id: Optional[int] = None):
         """Update status embeds. If `channel_id` is provided, only update the embed for that channel"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "cron-converter==1.0.2",
     "cryptography==44.0.0",
     "dataclasses-json==0.5.7",
-    "discord-py>=2.6.4",
+    "discord-py>=2.7.0",I
     "frozenlist==1.4.1",
     "httpx>=0.28.1",
     "httpx-sse>=0.4.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "cron-converter==1.0.2",
     "cryptography==44.0.0",
     "dataclasses-json==0.5.7",
-    "discord-py>=2.7.0",I
+    "discord-py>=2.7.0",
     "frozenlist==1.4.1",
     "httpx>=0.28.1",
     "httpx-sse>=0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -243,15 +243,15 @@ wheels = [
 
 [[package]]
 name = "discord-py"
-version = "2.6.4"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "audioop-lts" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/9b1dbb9b2fc07616132a526c05af23cfd420381793968a189ee08e12e35f/discord_py-2.6.4.tar.gz", hash = "sha256:44384920bae9b7a073df64ae9b14c8cf85f9274b5ad5d1d07bd5a67539de2da9", size = 1092623, upload-time = "2025-10-08T21:45:43.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/57/9a2d9abdabdc9db8ef28ce0cf4129669e1c8717ba28d607b5ba357c4de3b/discord_py-2.7.1.tar.gz", hash = "sha256:24d5e6a45535152e4b98148a9dd6b550d25dc2c9fb41b6d670319411641249da", size = 1106326, upload-time = "2026-03-03T18:40:46.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/ae/3d3a89b06f005dc5fa8618528dde519b3ba7775c365750f7932b9831ef05/discord_py-2.6.4-py3-none-any.whl", hash = "sha256:2783b7fb7f8affa26847bfc025144652c294e8fe6e0f8877c67ed895749eb227", size = 1209284, upload-time = "2025-10-08T21:45:41.679Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/17208c3b3f92319e7fad259f1c6d5a5baf8fd0654c54846ced329f83c3eb/discord_py-2.7.1-py3-none-any.whl", hash = "sha256:849dca2c63b171146f3a7f3f8acc04248098e9e6203412ce3cf2745f284f7439", size = 1227550, upload-time = "2026-03-03T18:40:44.492Z" },
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ requires-dist = [
     { name = "cron-converter", specifier = "==1.0.2" },
     { name = "cryptography", specifier = "==44.0.0" },
     { name = "dataclasses-json", specifier = "==0.5.7" },
-    { name = "discord-py", specifier = ">=2.6.4" },
+    { name = "discord-py", specifier = ">=2.7.0" },
     { name = "frozenlist", specifier = "==1.4.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.3" },


### PR DESCRIPTION
New enhancements to improve recruiter rewards:
- Added a new option to the report modal to report on days recruited (e.g. 5 out of 7 days)
- Added a new option to the report modal to report on streaks (i.e. days in a row recruited without interruption)
- Upgrading to discord.py 2.7.0 _note: I have only tested my own functionality with this, hopefully it is backwards compatible for existing functions_
- Certified works on my machine