### PR TITLE
Hotfixes

### DIFF
--- a/components/bot.py
+++ b/components/bot.py
@@ -140,7 +140,7 @@ class Bot(commands.Bot):
                 num = await cur.execute(
                     """SELECT users.id
                        FROM users
-                           JOIN recruitment_channels ON recruitment_channels.id = users.channelId
+                                JOIN recruitment_channels ON recruitment_channels.id = users.channelId
                        WHERE users.discordId = %s
                          AND recruitment_channels.channelId = %s;""",
                     (user.id, channel_id),
@@ -157,7 +157,7 @@ class Bot(commands.Bot):
                 num = await cur.execute(
                     """SELECT users.id, nation, recruitTemplate, allowRecruitmentAt, foundedTime
                        FROM users
-                           JOIN recruitment_channels ON recruitment_channels.id = users.channelId
+                                JOIN recruitment_channels ON recruitment_channels.id = users.channelId
                        WHERE users.discordId = %s
                          AND recruitment_channels.channelId = %s;
                     """,
@@ -216,15 +216,15 @@ class Bot(commands.Bot):
             async with conn.cursor() as cur:
                 await cur.execute(
                     """SELECT users.nation,
-                              SUM(nationCount)                          AS 'tgcount',
-                              COUNT(DISTINCT DATE(telegrams.timestamp)) AS 'days'
+                              SUM(nationCount) AS 'tgcount', COUNT(DISTINCT DATE (telegrams.timestamp)) AS 'days'
                        FROM telegrams
                                 JOIN users ON users.id = telegrams.recruiterId
                                 JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
                        WHERE telegrams.timestamp BETWEEN %s AND %s
                          AND recruitment_channels.channelId = %s
                        GROUP BY users.id
-                       ORDER BY tgcount DESC;
+                       ORDER BY tgcount DESC
+                       LIMIT 40;
                     """,
                     (start_time, end_time, channel_id),
                 )
@@ -238,25 +238,26 @@ class Bot(commands.Bot):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    """WITH daily AS (SELECT telegrams.recruiterId, DATE(telegrams.timestamp) AS dt
-                                      FROM telegrams
-                                               JOIN users ON users.id = telegrams.recruiterId
-                                               JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
-                                      WHERE recruitment_channels.channelId = %s
-                                      GROUP BY telegrams.recruiterId, DATE(telegrams.timestamp)),
-                            islands AS (SELECT recruiterId,
-                                               dt,
-                                               DATE_SUB(dt, INTERVAL
-                                                        ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
-                                                        DAY) AS island
-                                        FROM daily)
-                       SELECT users.nation, COUNT(*) AS streak_days
-                       FROM islands
-                                JOIN users ON users.id = islands.recruiterId
-                       GROUP BY islands.recruiterId, islands.island
-                       HAVING MAX(dt) >= %s
-                          AND MIN(dt) <= %s
-                       ORDER BY streak_days DESC;
+                    """WITH daily AS (SELECT telegrams.recruiterId, DATE (telegrams.timestamp) AS dt
+                       FROM telegrams
+                           JOIN users
+                       ON users.id = telegrams.recruiterId
+                           JOIN recruitment_channels ON recruitment_channels.id = telegrams.channelId
+                       WHERE recruitment_channels.channelId = %s
+                       GROUP BY telegrams.recruiterId, DATE (telegrams.timestamp)),
+                           islands AS (
+                       SELECT recruiterId, dt, DATE_SUB(dt, INTERVAL
+                           ROW_NUMBER() OVER (PARTITION BY recruiterId ORDER BY dt)
+                           DAY) AS island
+                       FROM daily)
+                    SELECT users.nation, COUNT(*) AS streak_days
+                    FROM islands
+                             JOIN users ON users.id = islands.recruiterId
+                    GROUP BY islands.recruiterId, islands.island
+                    HAVING streak_days >= 3
+                       AND MAX(dt) >= %s
+                       AND MIN(dt) <= %s
+                    ORDER BY streak_days DESC LIMIT 40;
                     """,
                     (channel_id, start_time, end_time),
                 )

--- a/components/bot.py
+++ b/components/bot.py
@@ -355,7 +355,10 @@ class Bot(commands.Bot):
 
                 from cogs.recruit import RecruitView
 
-                await message.edit(embed=embed, view=RecruitView(self))
+                try:
+                    await message.edit(embed=embed, view=RecruitView(self))
+                except discord.HTTPException as e:
+                    logger.warning("Failed to edit message %d in channel %d: %s", message_id, channel_id, e)
 
     async def update_status_embeds(self):
         async with self._pool.acquire() as conn:
@@ -365,7 +368,10 @@ class Bot(commands.Bot):
 
                 for channel in channels:
                     if type(channel_id := channel[0]) is not int:
-                        logger.warning("invalid type for channel_id: %s", type(channel_id))
+                        logger.warning("Invalid type for channel_id: %s", type(channel_id))
                         continue
 
-                    await self.update_status_embed(channel_id)
+                    try:
+                        await self.update_status_embed(channel_id)
+                    except Exception as e:
+                        logger.error("Failed to update status embed for channel %d: %s", channel_id, e)


### PR DESCRIPTION
Fixing a couple bugs that popped up after deploying filters & streaks to prod:

* After we changed refresh_embeds to refresh ALL embeds, rather than taking a channel ID as an optional parameter, this caused any one registered channel being deleted or archived to break the entire refresh loop. Added try/catch.
* Some users were very excited about the new report options and trying to run huge reports, breaking Discord's 2000 character limit for messages
* Also filtered out streaks shorter than 3 days to reduce the noise