### PR TITLE
Graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,9 +103,8 @@ ENV/
 
 # Other stuff
 logs/*
-settings.json
-config.json
+*.json
+*.sql
 queue.txt
 .run/Start Bot.run.xml
 .DS_Store
-schema.sql

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -1,3 +1,4 @@
+import discord
 from discord.ext import commands
 
 from components.bot import Bot
@@ -27,6 +28,33 @@ class Base(commands.Cog):
     async def kill(self, ctx: commands.Context):
         await ctx.reply("Goodbye!")
         await self.bot.close()
+
+    @commands.command(name="deregister", description="Deregister a recruitment channel by ID")
+    @commands.check(is_global_admin_text)
+    async def deregister(self, ctx: commands.Context, channel_id: int):
+        message_id = await self.bot.deregister_recruitment_channel(channel_id)
+
+        if message_id is None:
+            await ctx.reply(f"Channel {channel_id} is not a registered recruitment channel.")
+            return
+
+        # Removes channel from memory; bot.deregister call drops from DB
+        self.bot.queue_manager.remove_channel(channel_id)
+
+        channel = await self.bot.resolve_channel(channel_id)
+        if channel is not None:
+            try:
+                message = await channel.fetch_message(message_id)
+                await message.delete()
+            except discord.NotFound:
+                pass
+            except discord.HTTPException as e:
+                await ctx.reply(
+                    f"Deregistered channel {channel_id}, but failed to delete the status embed: {e}"
+                )
+                return
+
+        await ctx.reply(f"Deregistered channel {channel_id}.")
 
 
 async def setup(bot: Bot):

--- a/cogs/base.py
+++ b/cogs/base.py
@@ -1,4 +1,3 @@
-import discord
 from discord.ext import commands
 
 from components.bot import Bot
@@ -28,34 +27,6 @@ class Base(commands.Cog):
     async def kill(self, ctx: commands.Context):
         await ctx.reply("Goodbye!")
         await self.bot.close()
-
-    @commands.command(name="deregister", description="Deregister a recruitment channel by ID")
-    @commands.check(is_global_admin_text)
-    async def deregister(self, ctx: commands.Context, channel_id: int):
-        message_id = await self.bot.deregister_recruitment_channel(channel_id)
-
-        if message_id is None:
-            await ctx.reply(f"Channel {channel_id} is not a registered recruitment channel.")
-            return
-
-        # Removes channel from memory; bot.deregister call drops from DB
-        self.bot.queue_manager.remove_channel(channel_id)
-
-        channel = await self.bot.resolve_channel(channel_id)
-        if channel is not None:
-            try:
-                message = await channel.fetch_message(message_id)
-                await message.delete()
-            except discord.NotFound:
-                pass
-            except discord.HTTPException as e:
-                await ctx.reply(
-                    f"Deregistered channel {channel_id}, but failed to delete the status embed: {e}"
-                )
-                return
-
-        await ctx.reply(f"Deregistered channel {channel_id}.")
-
 
 async def setup(bot: Bot):
     await bot.add_cog(Base(bot))

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -38,11 +38,12 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
         async with self.bot.pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    "SELECT id FROM recruitment_channels WHERE channelId = %s;",
+                    "SELECT id, disabled FROM recruitment_channels WHERE channelId = %s;",
                     (interaction.channel.id,),
                 )
+                existing = await cur.fetchone()
 
-                if await cur.fetchone():
+                if existing and not existing[1]:
                     if interaction.channel.id not in self.bot.queue_manager._queues:
                         await cur.execute(
                             """SELECT region
@@ -66,24 +67,50 @@ class RegisterRecruitmentChannelModal(Modal, title="Register Recruitment Channel
                 message = await interaction.channel.send(view=RecruitView(self.bot))
 
                 try:
-                    await cur.execute(
-                        "INSERT INTO recruitment_channels (serverId, channelId, messageId) VALUES (%s, %s, %s);",
-                        (interaction.guild.id, interaction.channel.id, message.id),
-                    )
-
-                    await cur.execute(
-                        "INSERT INTO exceptions (channelId, region) VALUES ("
-                        "(SELECT id FROM recruitment_channels WHERE channelId = %s), %s);",
-                        (interaction.channel.id, region),
-                    )
-
-                    self.bot.queue_manager.add_channel(interaction.channel.id, [region])
+                    if existing:
+                        await cur.execute(
+                            """UPDATE recruitment_channels
+                               SET disabled  = FALSE,
+                                   serverId  = %s,
+                                   messageId = %s
+                               WHERE channelId = %s;""",
+                            (interaction.guild.id, message.id, interaction.channel.id),
+                        )
+                        await cur.execute(
+                            """INSERT IGNORE INTO exceptions (channelId, region)
+                               VALUES ((SELECT id FROM recruitment_channels WHERE channelId = %s), %s);""",
+                            (interaction.channel.id, region),
+                        )
+                        await cur.execute(
+                            """SELECT region
+                               FROM exceptions
+                                   JOIN recruitment_channels ON recruitment_channels.id = exceptions.channelId
+                               WHERE recruitment_channels.channelId = %s;""",
+                            (interaction.channel.id,),
+                        )
+                        regions = [r[0] for r in await cur.fetchall()]
+                        self.bot.queue_manager.add_channel(interaction.channel.id, regions)
+                        await interaction.response.send_message(
+                            f"Re-enabled channel for region: {region}.", ephemeral=True
+                        )
+                    else:
+                        await cur.execute(
+                            "INSERT INTO recruitment_channels (serverId, channelId, messageId) VALUES (%s, %s, %s);",
+                            (interaction.guild.id, interaction.channel.id, message.id),
+                        )
+                        await cur.execute(
+                            "INSERT INTO exceptions (channelId, region) VALUES ("
+                            "(SELECT id FROM recruitment_channels WHERE channelId = %s), %s);",
+                            (interaction.channel.id, region),
+                        )
+                        self.bot.queue_manager.add_channel(interaction.channel.id, [region])
+                        await interaction.response.send_message(
+                            f"Registered channel for region: {region}", ephemeral=True
+                        )
 
                 except Exception as e:
                     await message.delete()
                     raise e
-                else:
-                    await interaction.response.send_message(f"Registered channel for region: {region}", ephemeral=True)
 
     async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
         logger.exception(error)
@@ -390,9 +417,9 @@ class RecruitmentCog(commands.Cog):
 
         await interaction.response.send_message(f"Removed global filter: ``{pattern}``.", ephemeral=True)
 
-    @commands.command(name="deregister", description="Deregister a recruitment channel by ID")
+    @commands.command(name="disable", description="Disable a recruitment channel by ID")
     @commands.check(is_global_admin_text)
-    async def deregister(self, ctx: commands.Context, channel_id: int):
+    async def disable(self, ctx: commands.Context, channel_id: int):
         message_id = await self.bot.deregister_recruitment_channel(channel_id)
 
         if message_id is None:

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -7,7 +7,7 @@ from discord.ext import commands, tasks
 from discord.ui import Modal, View
 
 from components.bot import Bot
-from components.checks import is_global_admin
+from components.checks import is_global_admin, is_global_admin_text
 from components.errors import NationNotFound, WhitelistError
 
 logger = logging.getLogger("main")
@@ -389,6 +389,33 @@ class RecruitmentCog(commands.Cog):
         await self.bot.queue_manager.remove_global_filter(pattern)
 
         await interaction.response.send_message(f"Removed global filter: ``{pattern}``.", ephemeral=True)
+
+    @commands.command(name="deregister", description="Deregister a recruitment channel by ID")
+    @commands.check(is_global_admin_text)
+    async def deregister(self, ctx: commands.Context, channel_id: int):
+        message_id = await self.bot.deregister_recruitment_channel(channel_id)
+
+        if message_id is None:
+            await ctx.reply(f"Channel {channel_id} is not a registered recruitment channel.")
+            return
+
+        # Removes channel from memory; bot.deregister call drops from DB
+        self.bot.queue_manager.remove_channel(channel_id)
+
+        channel = await self.bot.resolve_channel(channel_id)
+        if channel is not None:
+            try:
+                message = await channel.fetch_message(message_id)
+                await message.delete()
+            except discord.NotFound:
+                pass
+            except discord.HTTPException as e:
+                await ctx.reply(
+                    f"Deregistered channel {channel_id}, but failed to delete the status embed: {e}"
+                )
+                return
+
+        await ctx.reply(f"Deregistered channel {channel_id}.")
 
 
 async def setup(bot: Bot):

--- a/cogs/recruit.py
+++ b/cogs/recruit.py
@@ -406,6 +406,8 @@ class RecruitmentCog(commands.Cog):
     @filter_command_group.command(name="add", description="add a global name filter")
     @app_commands.check(is_global_admin)
     async def add_filter(self, interaction: discord.Interaction, pattern: str):
+        pattern = pattern.lower()
+
         await self.bot.queue_manager.add_global_filter(pattern)
 
         await interaction.response.send_message(f"Added global filter: ``{pattern}``.", ephemeral=True)
@@ -413,9 +415,29 @@ class RecruitmentCog(commands.Cog):
     @filter_command_group.command(name="remove", description="remove a global name filter")
     @app_commands.check(is_global_admin)
     async def remove_filter(self, interaction: discord.Interaction, pattern: str):
+        pattern = pattern.lower()
+
         await self.bot.queue_manager.remove_global_filter(pattern)
 
         await interaction.response.send_message(f"Removed global filter: ``{pattern}``.", ephemeral=True)
+
+    @filter_command_group.command(name="test", description="list global filters that match a nation name")
+    @app_commands.check(is_global_admin)
+    async def test_filter(self, interaction: discord.Interaction, nation: str):
+        nation = nation.strip().lower().replace(" ", "_")
+
+        matches = self.bot.queue_manager.matching_filters(nation)
+
+        if not matches:
+            await interaction.response.send_message(
+                f"No global filters match ``{nation}``.", ephemeral=True
+            )
+            return
+
+        formatted = "\n".join(f"- ``{p}``" for p in matches)
+        await interaction.response.send_message(
+            f"Filters matching ``{nation}``:\n{formatted}", ephemeral=True
+        )
 
     @commands.command(name="disable", description="Disable a recruitment channel by ID")
     @commands.check(is_global_admin_text)

--- a/components/bot.py
+++ b/components/bot.py
@@ -106,6 +106,26 @@ class Bot(commands.Bot):
 
             # await conn.commit()
 
+    async def deregister_recruitment_channel(self, channel_id: int) -> Optional[int]:
+        """Delete a recruitment channel and return its status embed message id, or None if not registered."""
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT messageId FROM recruitment_channels WHERE channelId = %s;",
+                    (channel_id,),
+                )
+                row = await cur.fetchone()
+
+                if row is None:
+                    return None
+
+                await cur.execute(
+                    "DELETE FROM recruitment_channels WHERE channelId = %s;",
+                    (channel_id,),
+                )
+
+                return row[0]
+
     async def request(self, url: str) -> bs:
         current_time = datetime.now(timezone.utc)
 

--- a/components/bot.py
+++ b/components/bot.py
@@ -80,7 +80,7 @@ class Bot(commands.Bot):
 
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
-                await cur.execute("SELECT channelId, messageId FROM recruitment_channels;")
+                await cur.execute("SELECT channelId, messageId FROM recruitment_channels WHERE disabled = FALSE;")
                 recruitment_views = await cur.fetchall()
 
                 for _, message_id in recruitment_views:
@@ -107,11 +107,11 @@ class Bot(commands.Bot):
             # await conn.commit()
 
     async def deregister_recruitment_channel(self, channel_id: int) -> Optional[int]:
-        """Delete a recruitment channel and return its status embed message id, or None if not registered."""
+        """Disable a recruitment channel and return its status embed message id, or None if not actively registered."""
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    "SELECT messageId FROM recruitment_channels WHERE channelId = %s;",
+                    "SELECT messageId FROM recruitment_channels WHERE channelId = %s AND disabled = FALSE;",
                     (channel_id,),
                 )
                 row = await cur.fetchone()
@@ -120,7 +120,7 @@ class Bot(commands.Bot):
                     return None
 
                 await cur.execute(
-                    "DELETE FROM recruitment_channels WHERE channelId = %s;",
+                    "UPDATE recruitment_channels SET disabled = TRUE WHERE channelId = %s;",
                     (channel_id,),
                 )
 
@@ -162,7 +162,8 @@ class Bot(commands.Bot):
                        FROM users
                                 JOIN recruitment_channels ON recruitment_channels.id = users.channelId
                        WHERE users.discordId = %s
-                         AND recruitment_channels.channelId = %s;""",
+                         AND recruitment_channels.channelId = %s
+                         AND recruitment_channels.disabled = FALSE;""",
                     (user.id, channel_id),
                 )
 
@@ -179,7 +180,8 @@ class Bot(commands.Bot):
                        FROM users
                                 JOIN recruitment_channels ON recruitment_channels.id = users.channelId
                        WHERE users.discordId = %s
-                         AND recruitment_channels.channelId = %s;
+                         AND recruitment_channels.channelId = %s
+                         AND recruitment_channels.disabled = FALSE;
                     """,
                     (user.id, channel_id),
                 )
@@ -351,7 +353,10 @@ class Bot(commands.Bot):
 
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
-                await cur.execute("SELECT messageId FROM recruitment_channels WHERE channelId = %s;", channel_id)
+                await cur.execute(
+                    "SELECT messageId FROM recruitment_channels WHERE channelId = %s AND disabled = FALSE;",
+                    channel_id,
+                )
 
                 message_id = (await cur.fetchone())[0]
 
@@ -384,7 +389,7 @@ class Bot(commands.Bot):
     async def update_status_embeds(self):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
-                await cur.execute("SELECT channelId FROM recruitment_channels;")
+                await cur.execute("SELECT channelId FROM recruitment_channels WHERE disabled = FALSE;")
                 channels = await cur.fetchall()
 
                 for channel in channels:

--- a/components/config/config_manager.py
+++ b/components/config/config_manager.py
@@ -4,6 +4,7 @@ from logging import Logger
 from os import path
 
 from .config_model import ConfigData
+from .errors import ConfigError
 
 
 class ObjectEncoder(json.JSONEncoder):
@@ -49,16 +50,27 @@ class ConfigManager:
         print("READ")
         try:
             f = open("settings.json", "r")
+        except FileNotFoundError:
+            raise ConfigError(f"settings.json not found at {path.realpath('settings.json')}.")
+
+        try:
             open_message = f"Loading settings from: {path.realpath(f.name)}"
             if hasattr(self, "_std") and self._std is not None:
                 self._std.info(open_message)
             else:
                 print(open_message)
 
-            dict = json.load(f)
-            self._data = ConfigData.from_dict(dict)
-        except Exception as ex:
-            print(ex)
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                raise ConfigError(f"settings.json is malformed: {e}") from e
+        finally:
+            f.close()
+
+        try:
+            self._data = ConfigData.from_dict(data)
+        except KeyError as e:
+            raise ConfigError(f"settings.json is missing required field: {e.args[0]}") from e
         return
 
     def writeConfig(self) -> None:

--- a/components/config/errors.py
+++ b/components/config/errors.py
@@ -1,0 +1,3 @@
+class ConfigError(RuntimeError):
+    """Raised when settings.json is missing, malformed, or incomplete."""
+    pass

--- a/components/queue.py
+++ b/components/queue.py
@@ -6,7 +6,7 @@ import threading
 import time
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Self
 
 import aiomysql
@@ -102,6 +102,12 @@ class Queue:
     def get_nation_names(self) -> List[str]:
         return [nation.name for nation in self._nations]
 
+    def snapshot(self) -> List[Nation]:
+        return list(self._nations)
+
+    def restore(self, nations: List[Nation]):
+        self._nations.extend(n for n in nations if n.region not in self._whitelist)
+
     def prune(self):
         current_time = datetime.now(timezone.utc)
 
@@ -196,6 +202,7 @@ class QueueManager(AbstractAsyncContextManager):
     async def __aenter__(self):
         await self._init_channels()
         await self._init_filters()
+        self._load_from_disk()
 
         self._update_thread = threading.Thread(target=self._update, daemon=True)
 
@@ -204,7 +211,74 @@ class QueueManager(AbstractAsyncContextManager):
         return self
 
     async def __aexit__(self, exc_t, exc_v, exc_tb):
+        self._save_to_disk()
         self._running = False
+
+    def _save_to_disk(self, path: str = "queue_state.json"):
+        with self._queue_lock:
+            state = {
+                str(channel_id): [
+                    {
+                        "name": n.name,
+                        "region": n.region,
+                        "founding_time": n.founding_time.isoformat(),
+                    }
+                    for n in queue.snapshot()
+                ]
+                for channel_id, queue in self._queues.items()
+            }
+
+        try:
+            with open(path, "w") as f:
+                json.dump(state, f)
+            logger.info("Saved queue state to %s.", path)
+        except OSError as e:
+            logger.error("Failed to save queue state: %s", e)
+
+    def _load_from_disk(self, path: str = "queue_state.json"):
+        try:
+            with open(path, "r") as f:
+                state = json.load(f)
+        except FileNotFoundError:
+            logger.info("No queue state file found; starting with empty queues.")
+            return
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error("Failed to load queue state: %s", e)
+            return
+
+        current_time = datetime.now(timezone.utc)
+        max_age = timedelta(hours=1)
+
+        for channel_id_str, entries in state.items():
+            try:
+                channel_id = int(channel_id_str)
+            except ValueError:
+                logger.warning("Skipping invalid channel id in queue state: %s.", channel_id_str)
+                continue
+
+            if channel_id not in self._queues:
+                logger.info("Skipping queue state for unregistered channel %d.", channel_id)
+                continue
+
+            nations: List[Nation] = []
+            for entry in entries:
+                try:
+                    founding_time = datetime.fromisoformat(entry["founding_time"])
+                    region = entry["region"]
+                    name = entry["name"]
+                except (KeyError, TypeError, ValueError) as e:
+                    logger.warning("Skipping malformed nation in queue state: %s.", e)
+                    continue
+
+                if current_time - founding_time >= max_age:
+                    continue
+                if region in self._whitelist:
+                    continue
+
+                nations.append(Nation(name, region, founding_time))
+
+            self._queues[channel_id].restore(nations)
+            logger.info("Restored %d nations to queue for channel %d.", len(nations), channel_id)
 
     @property
     def global_whitelist(self):

--- a/components/queue.py
+++ b/components/queue.py
@@ -170,7 +170,7 @@ class QueueManager(AbstractAsyncContextManager):
     async def _init_channels(self):
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:
-                await cur.execute("SELECT channelId FROM recruitment_channels;")
+                await cur.execute("SELECT channelId FROM recruitment_channels WHERE disabled = FALSE;")
                 channels: List[int] = [channel[0] for channel in await cur.fetchall()]
 
                 for channel in channels:

--- a/components/queue.py
+++ b/components/queue.py
@@ -406,6 +406,10 @@ class QueueManager(AbstractAsyncContextManager):
         with self._queue_lock:
             self._queues[channel_id] = Queue(whitelist=regions)
 
+    def remove_channel(self, channel_id: int) -> bool:
+        with self._queue_lock:
+            return self._queues.pop(channel_id, None) is not None
+
     def get_nations(self, user: discord.User, channel_id: int, return_count: int = 8) -> List[str]:
         with self._queue_lock:
             return self._queues[channel_id].get_nations(user, return_count)

--- a/components/queue.py
+++ b/components/queue.py
@@ -398,6 +398,10 @@ class QueueManager(AbstractAsyncContextManager):
         with self._filter_lock:
             return any(nation_filter.match(nation) for nation_filter in self._filters)
 
+    def matching_filters(self, nation: str) -> List[str]:
+        with self._filter_lock:
+            return [f.pattern for f in self._filters if f.match(nation)]
+
     def channel(self, channel_id: int) -> Queue:
         with self._queue_lock:
             return self._queues[channel_id]

--- a/main.py
+++ b/main.py
@@ -2,9 +2,18 @@ import aiohttp
 import aiomysql
 import asyncio
 import logging
+import signal
+import sys
+
+from components.config.errors import ConfigError
+
+try:
+    from components.config.config_manager import configInstance
+except ConfigError as e:
+    print(f"Error loading configuration: {e}", file=sys.stderr)
+    sys.exit(1)
 
 from components.bot import Bot
-from components.config.config_manager import configInstance
 from components.queue import QueueManager
 
 logger = logging.getLogger("main")
@@ -25,10 +34,27 @@ async def main():
             init_command="SET SESSION time_zone='+00:00'",
         )
 
-        async with QueueManager(pool) as ql:
-            async with Bot(session, ql, pool) as bot:
-                await bot.start(configInstance.data.bot_token)
+        try:
+            async with QueueManager(pool) as ql:
+                async with Bot(session, ql, pool) as bot:
+                    if sys.platform != "win32":
+                        loop = asyncio.get_running_loop()
+
+                        def request_shutdown(signame: str):
+                            logger.info("Received %s, shutting down.", signame)
+                            asyncio.create_task(bot.close())
+
+                        for sig in (signal.SIGINT, signal.SIGTERM):
+                            loop.add_signal_handler(sig, request_shutdown, sig.name)
+
+                    await bot.start(configInstance.data.bot_token)
+        finally:
+            pool.close()
+            await pool.wait_closed()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Shutdown complete.")

--- a/settings.json.default
+++ b/settings.json.default
@@ -1,18 +1,19 @@
 {
-  "dbHost": "localhost",
-  "dbPort": 3306,
-  "dbUser": "",
-  "dbPassword": "",
-  "dbName": "ns"
+  "db_host": "localhost",
+  "db_port": 3306,
+  "db_user": "",
+  "db_password": "",
+  "db_name": "ns"
   "operator": "UPC",
-  "guildId": 0,
-  "reportChannelId": 0,
-  "recruitChannelId": 0,
-  "recruitRoleId": 0,
-  "statusMessageId": 0,
-  "pollingRate": 15,
+  "guild_id": 0,
+  "report_channel_id": 0,
+  "recruit_channel_id": 0,
+  "recruit_role_id": 0,
+  "status_message_id": 0,
+  "polling_rate": 15,
   "period": 30,
-  "periodMax": 5,
-  "botToken": "<Discord Bot Token>",
-  "recruitmentExceptions": []
+  "period_max": 5,
+  "bot_token": "<Discord Bot Token>",
+  "recruitment_exceptions": [],
+  "global_administrators": []
 }


### PR DESCRIPTION
"WHY CAN'T YOU JUST BE NORMAL?" 

Not sure if all of these changes will be super helpful in prod but I keep running into these problems in testing so figured I would fix them.

- Gracefully handle CTRL+C, SIGINT, SIGTERM, etc.
- Save the recruitment queue to disk on shutdown (that way we don't skip 100+ nations in the event of a crash or reboot)
- Load the recruitment queue from disk on startup, also check that they aren't super old or whitelisted
- Add a !deregister command to get rid of broken/etc. channels