### PR TITLE
fix: replace re.match with re.search

### DIFF
--- a/components/queue.py
+++ b/components/queue.py
@@ -387,11 +387,11 @@ class QueueManager(AbstractAsyncContextManager):
 
     def _is_filtered(self, nation: str) -> bool:
         with self._filter_lock:
-            return any(nation_filter.match(nation) for nation_filter in self._filters)
+            return any(nation_filter.search(nation) for nation_filter in self._filters)
 
     def matching_filters(self, nation: str) -> List[str]:
         with self._filter_lock:
-            return [f.pattern for f in self._filters if f.match(nation)]
+            return [f.pattern for f in self._filters if f.search(nation)]
 
     def channel(self, channel_id: int) -> Queue:
         with self._queue_lock:


### PR DESCRIPTION
the former is anchored to the beginning of a string, while the latter searches the entire string. this is why our roman numeral filter wasn't working
